### PR TITLE
Add User-Configurable FLAC Support Toggle

### DIFF
--- a/LMS_StreamTest/ContentView.swift
+++ b/LMS_StreamTest/ContentView.swift
@@ -96,6 +96,7 @@ struct ContentView: View {
             }
         }) {
             SettingsView()
+                .environmentObject(slimProtoCoordinator)
         }
 
     }

--- a/LMS_StreamTest/SlimProtoClient.swift
+++ b/LMS_StreamTest/SlimProtoClient.swift
@@ -276,8 +276,8 @@ class SlimProtoClient: NSObject, GCDAsyncSocketDelegate, ObservableObject {
         // Language (2 bytes) - optional, "en"
         helloData.append("en".data(using: .ascii) ?? Data([0x65, 0x6e]))
         
-        // *** FIXED: Enhanced capabilities string with proper player identification ***
-        let capabilities = "Model=squeezelite,AccuratePlayPoints=1,HasDigitalOut=1,HasPolarityInversion=1,Balance=1,Firmware=v1.0.0-iOS,ModelName=SqueezeLite,MaxSampleRate=48000,flc,aac,mp3"
+        // *** FIXED: Enhanced capabilities string with user-configurable FLAC support ***
+        let capabilities = settings.capabilitiesString
         if let capabilitiesData = capabilities.data(using: .utf8) {
             helloData.append(capabilitiesData)
             os_log(.info, log: logger, "Added capabilities: %{public}s", capabilities)

--- a/LMS_StreamTest/SlimProtoCoordinator.swift
+++ b/LMS_StreamTest/SlimProtoCoordinator.swift
@@ -116,6 +116,23 @@ class SlimProtoCoordinator: ObservableObject {
         client.disconnect()
     }
     
+    func restartConnection() async {
+        os_log(.info, log: logger, "🔄 Restarting connection to apply new capabilities...")
+        
+        // Disconnect from server
+        disconnect()
+        
+        // Wait briefly for clean disconnect
+        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        
+        // Reconnect with new capabilities
+        await MainActor.run {
+            connect()
+        }
+        
+        os_log(.info, log: logger, "✅ Connection restart completed")
+    }
+    
     func updateServerSettings(host: String, port: UInt16) {
         // Store current settings for change detection
         lastKnownHost = host


### PR DESCRIPTION
## Summary
Adds a user-configurable FLAC support toggle that allows users to disable native FLAC streaming, forcing server-side transcoding to MP3/AAC for compatibility or preference.

## Changes Made
- **SettingsManager**: Added `flacEnabled` boolean property with UserDefaults persistence
- **Dynamic Capabilities**: Created computed property that conditionally includes "flc" format
- **SlimProtoClient**: Updated to use dynamic capabilities string instead of hardcoded values  
- **Settings UI**: Added toggle with clear description: "Disabled = MP3 transcode • Auto-reconnects"
- **Auto-Reconnect**: Connection automatically restarts when setting changes to apply new capabilities immediately
- **User Feedback**: Visual "Reconnecting..." indicator during the brief reconnection process

## Technical Details
- Settings save immediately to UserDefaults
- Only reconnects if currently connected (graceful handling)
- Uses async/await for smooth UI experience during reconnection
- Maintains all existing connection management logic
- Clean separation of concerns across components

## User Experience
1. User toggles FLAC support in Settings → Audio Settings
2. If connected, app automatically reconnects (~0.5 seconds) 
3. Server receives new HELO with updated format capabilities
4. FLAC files will now stream natively (enabled) or transcode to MP3 (disabled)

## Benefits
- ✅ Gives users control over FLAC vs transcoded playback
- ✅ Useful for testing server transcoding capabilities
- ✅ Seamless experience with automatic reconnection
- ✅ Clear UI feedback during the process
- ✅ No manual app restart required

🤖 Generated with [Claude Code](https://claude.ai/code)