### PR TITLE
Fix auth missing from metadata, cover art, and playback controls

### DIFF
--- a/LMS_StreamTest.xcodeproj/project.pbxproj
+++ b/LMS_StreamTest.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LMS_StreamTest.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LMS_StreamTest/Preview Content\"";
 				DEVELOPMENT_TEAM = 74BKX23N3K;
 				ENABLE_PREVIEWS = YES;
@@ -595,7 +595,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -628,7 +628,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = LMS_StreamTest.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LMS_StreamTest/Preview Content\"";
 				DEVELOPMENT_TEAM = 74BKX23N3K;
 				ENABLE_PREVIEWS = YES;
@@ -664,7 +664,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/LMS_StreamTest/CarPlaySceneDelegate.swift
+++ b/LMS_StreamTest/CarPlaySceneDelegate.swift
@@ -787,6 +787,11 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPN
         var request = URLRequest(url: url)
         request.timeoutInterval = 3.0
 
+        // Add HTTP Basic Authentication if configured (for password-protected LMS servers)
+        if let authHeader = settings.generateAuthHeader() {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+
         URLSession.shared.dataTask(with: request) { data, response, error in
             if let data = data, let image = UIImage(data: data) {
                 completion(image)

--- a/LMS_StreamTest/NowPlayingManager.swift
+++ b/LMS_StreamTest/NowPlayingManager.swift
@@ -344,8 +344,14 @@ class NowPlayingManager: ObservableObject {
     
     private func loadArtwork(from url: URL) {
         os_log(.info, log: logger, "🖼️ Loading artwork from: %{public}s", url.absoluteString)
-        
-        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+
+        // Add HTTP Basic Authentication if configured (for password-protected LMS servers)
+        var request = URLRequest(url: url)
+        if let authHeader = SettingsManager.shared.generateAuthHeader() {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             DispatchQueue.main.async {
                 if let error = error {
                     os_log(.error, log: self?.logger ?? OSLog.disabled, "❌ Failed to load artwork: %{public}s", error.localizedDescription)

--- a/LMS_StreamTest/SlimProtoCoordinator.swift
+++ b/LMS_StreamTest/SlimProtoCoordinator.swift
@@ -1520,7 +1520,12 @@ extension SlimProtoCoordinator {
         request.setValue(settings.customUserAgent, forHTTPHeaderField: "User-Agent")
         request.httpBody = jsonData
         request.timeoutInterval = 10.0
-        
+
+        // Add HTTP Basic Authentication if configured
+        if let authHeader = settings.generateAuthHeader() {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
             DispatchQueue.main.async {
                 if let error = error {
@@ -1827,7 +1832,12 @@ extension SlimProtoCoordinator {
         request.setValue(settings.customUserAgent, forHTTPHeaderField: "User-Agent")
         request.httpBody = jsonData
         request.timeoutInterval = 5.0
-        
+
+        // Add HTTP Basic Authentication if configured
+        if let authHeader = settings.generateAuthHeader() {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
             if let error = error {
                 os_log(.error, log: self.logger, "Enhanced metadata request failed: %{public}s", error.localizedDescription)
@@ -1878,6 +1888,11 @@ extension SlimProtoCoordinator {
                     artworkURL = artwork.hasPrefix("http") ? artwork : "http://\(settings.activeServerHost):\(settings.activeServerWebPort)\(artwork)"
                 } else if let coverid = firstTrack["coverid"] as? String, !coverid.isEmpty, coverid != "0" {
                     artworkURL = "http://\(settings.activeServerHost):\(settings.activeServerWebPort)/music/\(coverid)/cover.jpg"
+                }
+
+                // Inject credentials for password-protected LMS servers
+                if let url = artworkURL {
+                    artworkURL = settings.injectCredentialsIntoURL(url)
                 }
 
                 // Log final metadata result


### PR DESCRIPTION
## Summary
- Users with password-protected LMS servers could play audio but got no cover art, metadata, or working lock screen/CarPlay controls
- The auth implementation (Dec 2025) injected credentials into stream URLs but missed 5 other HTTP request paths that also require authentication
- Added `generateAuthHeader()` / `injectCredentialsIntoURL()` to all missed locations, matching the existing pattern

## Changes
| File | Fix |
|------|-----|
| `SlimProtoCoordinator.swift` | Auth header on `sendJSONCommand()` (play/pause/skip) |
| `SlimProtoCoordinator.swift` | Auth header on `fetchCurrentTrackMetadata()` (JSON-RPC) |
| `SlimProtoCoordinator.swift` | Credential injection into constructed artwork URLs |
| `NowPlayingManager.swift` | Auth header on lock screen artwork fetch |
| `CarPlaySceneDelegate.swift` | Auth header on CarPlay artwork fetch |

## Test plan
- [x] Test with password-protected LMS: lock screen shows title, artist, album art
- [x] Test with password-protected LMS: lock screen play/pause/skip controls work
- [x] Test with password-protected LMS: CarPlay browse shows album artwork
- [x] Regression: non-authenticated server still works normally

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)