### PR TITLE
tvOS: extract SlimProtoJSONRPCRunner protocol + cancellation-token unit tests (LMS_StreamTest-98q.13)

### DIFF
--- a/LMS_StreamTest-tvOS/FavoritesView.swift
+++ b/LMS_StreamTest-tvOS/FavoritesView.swift
@@ -10,7 +10,9 @@ import os.log
 ///
 /// Tap-to-play stays on the Library tab per D6 (CarPlay convention).
 struct FavoritesView: View {
-    let coordinator: SlimProtoCoordinator
+    // Only needs the stateless JSON-RPC seam (98q.13) — no playback control,
+    // no child views that require the concrete coordinator.
+    let coordinator: any SlimProtoJSONRPCRunner
     @ObservedObject var settings: SettingsManager
 
     @State private var items: [FavoriteItem] = []

--- a/LMS_StreamTest-tvOS/SearchResultsModel.swift
+++ b/LMS_StreamTest-tvOS/SearchResultsModel.swift
@@ -1,0 +1,174 @@
+import Combine
+import Foundation
+import os.log
+
+/// Per-domain search fan-out + D5=B cancellation token, extracted from
+/// SearchView (98q.13) so the stale-response guard is unit-testable against a
+/// mocked `SlimProtoJSONRPCRunner` instead of OSLog inspection on hardware.
+///
+/// Main-thread only, like the view `@State` it replaced: completions marshal
+/// to main via `DispatchQueue.main.async` before touching `@Published` state.
+final class SearchResultsModel: ObservableObject {
+    // Per-domain results.
+    @Published private(set) var artistResults: [Artist] = []
+    @Published private(set) var albumResults: [Album] = []
+    @Published private(set) var trackResults: [PlaylistTrack] = []
+    @Published private(set) var playlistResults: [Playlist] = []
+
+    // Lifecycle gates — drive SearchView's spinner / no-results states.
+    @Published private(set) var hasFetched: Bool = false
+    @Published private(set) var inFlight: Int = 0
+
+    // D5=B cancellation token. Every fan-out gets a fresh UUID; responses with
+    // a stale token bail without touching results.
+    private var lastQueryToken: UUID = UUID()
+
+    private let runner: any SlimProtoJSONRPCRunner
+    private let logger = OSLog(subsystem: "com.lmsstream", category: "SearchResultsModel")
+    /// D6=B: 25 results per domain (matches lms-material LMS_INITIAL_SEARCH_RESULTS).
+    private let resultLimit = 25
+
+    init(runner: any SlimProtoJSONRPCRunner) {
+        self.runner = runner
+    }
+
+    var allResultsEmpty: Bool {
+        artistResults.isEmpty
+            && albumResults.isEmpty
+            && trackResults.isEmpty
+            && playlistResults.isEmpty
+    }
+
+    /// Reset to the pre-search state (empty or sub-2-char query).
+    func reset() {
+        artistResults = []
+        albumResults = []
+        trackResults = []
+        playlistResults = []
+        hasFetched = false
+        inFlight = 0
+    }
+
+    func fireSearch(for term: String) {
+        let token = UUID()
+        lastQueryToken = token
+        inFlight = 4
+        // Don't reset hasFetched here — keep prior results visible while the new
+        // query is in flight (Material UI pattern).
+
+        os_log(.info, log: logger, "🔎 Search fan-out for \"%{public}s\" [token=%{public}s]",
+               term, token.uuidString)
+
+        fetchArtists(term: term, token: token)
+        fetchAlbums(term: term, token: token)
+        fetchTracks(term: term, token: token)
+        fetchPlaylists(term: term, token: token)
+    }
+
+    private func fetchArtists(term: String, token: UUID) {
+        let cmd: [String: Any] = [
+            "id": 1,
+            "method": "slim.request",
+            "params": ["", ["artists", 0, resultLimit, "tags:s", "search:\(term)"]]
+        ]
+        runner.sendJSONRPCCommandDirect(cmd) { [weak self] response in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard token == self.lastQueryToken else {
+                    os_log(.info, log: self.logger, "🚫 Stale artists response [token=%{public}s]", token.uuidString)
+                    return
+                }
+                if let result = response["result"] as? [String: Any],
+                   let loop = result["artists_loop"] as? [[String: Any]] {
+                    self.artistResults = Artist.parseLoop(loop)
+                } else {
+                    self.artistResults = []
+                }
+                self.completeOne(label: "artists", count: self.artistResults.count)
+            }
+        }
+    }
+
+    private func fetchAlbums(term: String, token: UUID) {
+        // tags:ajly matches AlbumListView (98q.9). The `j` tag returns artwork_track_id
+        // which LMSArtworkURL.cover needs — without it, fallback to album.id builds a
+        // URL LMS does not serve (album covers live under their first track's id).
+        let cmd: [String: Any] = [
+            "id": 1,
+            "method": "slim.request",
+            "params": ["", ["albums", 0, resultLimit, "tags:ajly", "search:\(term)"]]
+        ]
+        runner.sendJSONRPCCommandDirect(cmd) { [weak self] response in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard token == self.lastQueryToken else {
+                    os_log(.info, log: self.logger, "🚫 Stale albums response [token=%{public}s]", token.uuidString)
+                    return
+                }
+                if let result = response["result"] as? [String: Any],
+                   let loop = result["albums_loop"] as? [[String: Any]] {
+                    self.albumResults = Album.parseLoop(loop)
+                } else {
+                    self.albumResults = []
+                }
+                self.completeOne(label: "albums", count: self.albumResults.count)
+            }
+        }
+    }
+
+    private func fetchTracks(term: String, token: UUID) {
+        let cmd: [String: Any] = [
+            "id": 1,
+            "method": "slim.request",
+            "params": ["", ["tracks", 0, resultLimit, "tags:elcy", "search:\(term)"]]
+        ]
+        runner.sendJSONRPCCommandDirect(cmd) { [weak self] response in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard token == self.lastQueryToken else {
+                    os_log(.info, log: self.logger, "🚫 Stale tracks response [token=%{public}s]", token.uuidString)
+                    return
+                }
+                if let result = response["result"] as? [String: Any],
+                   let loop = result["titles_loop"] as? [[String: Any]] {
+                    // LMS tracks query returns `titles_loop` (the row name is "title", not "track").
+                    self.trackResults = PlaylistTrack.parseLoop(loop)
+                } else {
+                    self.trackResults = []
+                }
+                self.completeOne(label: "tracks", count: self.trackResults.count)
+            }
+        }
+    }
+
+    private func fetchPlaylists(term: String, token: UUID) {
+        let cmd: [String: Any] = [
+            "id": 1,
+            "method": "slim.request",
+            "params": ["", ["playlists", 0, resultLimit, "tags:su", "search:\(term)"]]
+        ]
+        runner.sendJSONRPCCommandDirect(cmd) { [weak self] response in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard token == self.lastQueryToken else {
+                    os_log(.info, log: self.logger, "🚫 Stale playlists response [token=%{public}s]", token.uuidString)
+                    return
+                }
+                if let result = response["result"] as? [String: Any],
+                   let loop = result["playlists_loop"] as? [[String: Any]] {
+                    self.playlistResults = Playlist.parseLoop(loop)
+                } else {
+                    self.playlistResults = []
+                }
+                self.completeOne(label: "playlists", count: self.playlistResults.count)
+            }
+        }
+    }
+
+    private func completeOne(label: String, count: Int) {
+        inFlight = max(0, inFlight - 1)
+        hasFetched = true
+        os_log(.info, log: logger, "✅ Search %{public}s: %d items (inFlight=%d)",
+               label, count, inFlight)
+    }
+}

--- a/LMS_StreamTest-tvOS/SearchView.swift
+++ b/LMS_StreamTest-tvOS/SearchView.swift
@@ -26,19 +26,10 @@ struct SearchView: View {
 
     @State private var searchTerm: String = ""
 
-    // Per-domain results.
-    @State private var artistResults: [Artist] = []
-    @State private var albumResults: [Album] = []
-    @State private var trackResults: [PlaylistTrack] = []
-    @State private var playlistResults: [Playlist] = []
-
-    // Lifecycle gates.
-    @State private var hasFetched: Bool = false
-    @State private var inFlight: Int = 0
-
-    // D5=B cancellation token. Every fan-out gets a fresh UUID; responses with
-    // a stale token bail without touching results.
-    @State private var lastQueryToken: UUID = UUID()
+    // Per-domain results + lifecycle gates + D5=B cancellation token, extracted
+    // to a testable model (98q.13). The view owns debounce + history + drill-in;
+    // the model owns the fan-out and the stale-response guard.
+    @StateObject private var results: SearchResultsModel
 
     // Debounce timer.
     @State private var debounceTask: Task<Void, Never>? = nil
@@ -56,19 +47,28 @@ struct SearchView: View {
     @State private var selectedDrill: BuiltinTrackListView.Source? = nil
 
     private let logger = OSLog(subsystem: "com.lmsstream", category: "SearchView")
-    private let resultLimit = 25
     private let debounceMs: UInt64 = 500_000_000  // 500ms in ns
+
+    init(coordinator: SlimProtoCoordinator, settings: SettingsManager) {
+        self.coordinator = coordinator
+        _settings = ObservedObject(wrappedValue: settings)
+        // The model pins the coordinator captured at first install for this view
+        // identity. Safe today because ContentView's server-change path tears the
+        // TabView down (isConnected flips false), destroying this identity — if
+        // that ever changes, the model keeps firing at the old coordinator.
+        _results = StateObject(wrappedValue: SearchResultsModel(runner: coordinator))
+    }
 
     var body: some View {
         TVScreen {
             Group {
                 if searchTerm.isEmpty {
                     preSearchView
-                } else if inFlight > 0 && !hasFetched {
+                } else if results.inFlight > 0 && !results.hasFetched {
                     ProgressView()
                         .scaleEffect(2.0)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if allResultsEmpty && hasFetched {
+                } else if results.allResultsEmpty && results.hasFetched {
                     noResultsView
                 } else {
                     resultsView
@@ -89,7 +89,7 @@ struct SearchView: View {
         }
         .onDisappear {
             // Cancel any pending debounce so a tab switch mid-debounce doesn't fire 4
-            // unnecessary JSON-RPC requests against detached @State.
+            // unnecessary JSON-RPC requests against a model nobody is rendering.
             debounceTask?.cancel()
         }
         .fullScreenCover(item: $selectedArtist) { artist in
@@ -185,9 +185,9 @@ struct SearchView: View {
         // D3=A: sectioned single screen. Empty sections suppressed.
         // ForEach identity by parsed item id (98q.9 /review hardening).
         TVList {
-            if !artistResults.isEmpty {
+            if !results.artistResults.isEmpty {
                 Section {
-                    ForEach(artistResults) { artist in
+                    ForEach(results.artistResults) { artist in
                         Button { tapArtist(artist) } label: {
                             MediaRow(
                                 primary: artist.name,
@@ -202,9 +202,9 @@ struct SearchView: View {
                     Text("Artists").tvSectionHeader()
                 }
             }
-            if !albumResults.isEmpty {
+            if !results.albumResults.isEmpty {
                 Section {
-                    ForEach(albumResults, id: \.id) { album in
+                    ForEach(results.albumResults, id: \.id) { album in
                         Button { tapAlbum(album) } label: {
                             MediaRow(
                                 primary: album.name,
@@ -224,9 +224,9 @@ struct SearchView: View {
                     Text("Albums").tvSectionHeader()
                 }
             }
-            if !trackResults.isEmpty {
+            if !results.trackResults.isEmpty {
                 Section {
-                    ForEach(trackResults, id: \.id) { track in
+                    ForEach(results.trackResults, id: \.id) { track in
                         Button { tapTrack(track) } label: {
                             MediaRow(
                                 primary: track.title,
@@ -245,9 +245,9 @@ struct SearchView: View {
                     Text("Tracks").tvSectionHeader()
                 }
             }
-            if !playlistResults.isEmpty {
+            if !results.playlistResults.isEmpty {
                 Section {
-                    ForEach(playlistResults, id: \.id) { playlist in
+                    ForEach(results.playlistResults, id: \.id) { playlist in
                         Button { tapPlaylist(playlist) } label: {
                             MediaRow(
                                 primary: playlist.name,
@@ -272,15 +272,6 @@ struct SearchView: View {
         return display.isEmpty ? nil : display
     }
 
-    // MARK: - Result aggregation
-
-    private var allResultsEmpty: Bool {
-        artistResults.isEmpty
-            && albumResults.isEmpty
-            && trackResults.isEmpty
-            && playlistResults.isEmpty
-    }
-
     // MARK: - Debounce + fan-out
 
     private func scheduleSearch(for term: String) {
@@ -290,12 +281,7 @@ struct SearchView: View {
 
         // Empty: reset to pre-search state.
         if trimmed.isEmpty {
-            artistResults = []
-            albumResults = []
-            trackResults = []
-            playlistResults = []
-            hasFetched = false
-            inFlight = 0
+            results.reset()
             return
         }
 
@@ -304,12 +290,7 @@ struct SearchView: View {
         // Reset results so backspacing from "pink" to "p" doesn't leave stale results
         // on screen with the search bar showing "p".
         if trimmed.count < 2 {
-            artistResults = []
-            albumResults = []
-            trackResults = []
-            playlistResults = []
-            hasFetched = false
-            inFlight = 0
+            results.reset()
             return
         }
 
@@ -321,125 +302,9 @@ struct SearchView: View {
     }
 
     private func fireSearch(for term: String) {
-        let token = UUID()
-        lastQueryToken = token
-        inFlight = 4
-        // Don't reset hasFetched here — keep prior results visible while the new
-        // query is in flight (Material UI pattern).
-
         SearchHistoryStore.add(query: term)
         history = SearchHistoryStore.all()
-
-        os_log(.info, log: logger, "🔎 Search fan-out for \"%{public}s\" [token=%{public}s]",
-               term, token.uuidString)
-
-        fetchArtists(term: term, token: token)
-        fetchAlbums(term: term, token: token)
-        fetchTracks(term: term, token: token)
-        fetchPlaylists(term: term, token: token)
-    }
-
-    private func fetchArtists(term: String, token: UUID) {
-        let cmd: [String: Any] = [
-            "id": 1,
-            "method": "slim.request",
-            "params": ["", ["artists", 0, resultLimit, "tags:s", "search:\(term)"]]
-        ]
-        coordinator.sendJSONRPCCommandDirect(cmd) { response in
-            DispatchQueue.main.async {
-                guard token == lastQueryToken else {
-                    os_log(.info, log: logger, "🚫 Stale artists response [token=%{public}s]", token.uuidString)
-                    return
-                }
-                if let result = response["result"] as? [String: Any],
-                   let loop = result["artists_loop"] as? [[String: Any]] {
-                    artistResults = Artist.parseLoop(loop)
-                } else {
-                    artistResults = []
-                }
-                completeOne(label: "artists", count: artistResults.count)
-            }
-        }
-    }
-
-    private func fetchAlbums(term: String, token: UUID) {
-        // tags:ajly matches AlbumListView (98q.9). The `j` tag returns artwork_track_id
-        // which LMSArtworkURL.cover needs — without it, fallback to album.id builds a
-        // URL LMS does not serve (album covers live under their first track's id).
-        let cmd: [String: Any] = [
-            "id": 1,
-            "method": "slim.request",
-            "params": ["", ["albums", 0, resultLimit, "tags:ajly", "search:\(term)"]]
-        ]
-        coordinator.sendJSONRPCCommandDirect(cmd) { response in
-            DispatchQueue.main.async {
-                guard token == lastQueryToken else {
-                    os_log(.info, log: logger, "🚫 Stale albums response [token=%{public}s]", token.uuidString)
-                    return
-                }
-                if let result = response["result"] as? [String: Any],
-                   let loop = result["albums_loop"] as? [[String: Any]] {
-                    albumResults = Album.parseLoop(loop)
-                } else {
-                    albumResults = []
-                }
-                completeOne(label: "albums", count: albumResults.count)
-            }
-        }
-    }
-
-    private func fetchTracks(term: String, token: UUID) {
-        let cmd: [String: Any] = [
-            "id": 1,
-            "method": "slim.request",
-            "params": ["", ["tracks", 0, resultLimit, "tags:elcy", "search:\(term)"]]
-        ]
-        coordinator.sendJSONRPCCommandDirect(cmd) { response in
-            DispatchQueue.main.async {
-                guard token == lastQueryToken else {
-                    os_log(.info, log: logger, "🚫 Stale tracks response [token=%{public}s]", token.uuidString)
-                    return
-                }
-                if let result = response["result"] as? [String: Any],
-                   let loop = result["titles_loop"] as? [[String: Any]] {
-                    // LMS tracks query returns `titles_loop` (the row name is "title", not "track").
-                    trackResults = PlaylistTrack.parseLoop(loop)
-                } else {
-                    trackResults = []
-                }
-                completeOne(label: "tracks", count: trackResults.count)
-            }
-        }
-    }
-
-    private func fetchPlaylists(term: String, token: UUID) {
-        let cmd: [String: Any] = [
-            "id": 1,
-            "method": "slim.request",
-            "params": ["", ["playlists", 0, resultLimit, "tags:su", "search:\(term)"]]
-        ]
-        coordinator.sendJSONRPCCommandDirect(cmd) { response in
-            DispatchQueue.main.async {
-                guard token == lastQueryToken else {
-                    os_log(.info, log: logger, "🚫 Stale playlists response [token=%{public}s]", token.uuidString)
-                    return
-                }
-                if let result = response["result"] as? [String: Any],
-                   let loop = result["playlists_loop"] as? [[String: Any]] {
-                    playlistResults = Playlist.parseLoop(loop)
-                } else {
-                    playlistResults = []
-                }
-                completeOne(label: "playlists", count: playlistResults.count)
-            }
-        }
-    }
-
-    private func completeOne(label: String, count: Int) {
-        inFlight = max(0, inFlight - 1)
-        hasFetched = true
-        os_log(.info, log: logger, "✅ Search %{public}s: %d items (inFlight=%d)",
-               label, count, inFlight)
+        results.fireSearch(for: term)
     }
 
     // MARK: - Tap handlers

--- a/LMS_StreamTest-tvOSTests/SearchResultsModelTests.swift
+++ b/LMS_StreamTest-tvOSTests/SearchResultsModelTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import Foundation
+@testable import LMS_StreamTest_tvOS
+
+/// Tests for `SearchResultsModel` — the per-domain search fan-out + D5=B
+/// UUID cancellation token extracted from SearchView (98q.13). Before this,
+/// the stale-response guard was verified only via OSLog inspection during
+/// hardware /review; a regression (e.g. await hoisting past the token check)
+/// would have shipped silently.
+///
+/// The mock captures completions instead of completing inline, so tests can
+/// deliver responses late and out of order — the exact race the token guards.
+@MainActor
+struct SearchResultsModelTests {
+
+    /// Captures every fan-out call; tests complete them manually.
+    final class MockRunner: SlimProtoJSONRPCRunner {
+        /// (domain, completion) in arrival order — 4 per fireSearch:
+        /// artists, albums, tracks, playlists.
+        private(set) var pending: [(domain: String, complete: ([String: Any]) -> Void)] = []
+
+        func sendJSONRPCCommandDirect(_ jsonRPC: [String: Any], completion: @escaping ([String: Any]) -> Void) {
+            // params: ["", ["<domain>", 0, 25, ...]] — inner array head names the domain.
+            let domain = ((jsonRPC["params"] as? [Any])?.last as? [Any])?.first as? String ?? "?"
+            pending.append((domain, completion))
+        }
+    }
+
+    /// A minimal LMS response for the given domain with one named item.
+    /// Tracks/playlists decode via Codable with more required fields than this
+    /// test needs — they get empty results; artists/albums carry the payload.
+    private func response(for domain: String, name: String) -> [String: Any] {
+        switch domain {
+        case "artists": return ["result": ["artists_loop": [["id": "1", "artist": name]]]]
+        case "albums": return ["result": ["albums_loop": [["id": "1", "album": name]]]]
+        default: return ["result": [String: Any]()]
+        }
+    }
+
+    /// The model's completions hop through `DispatchQueue.main.async` before
+    /// touching state; one more hop sequences the assertions after them.
+    private func drainMainQueue() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+    }
+
+    @Test func happyPathLandsResults() async {
+        let runner = MockRunner()
+        let model = SearchResultsModel(runner: runner)
+
+        model.fireSearch(for: "pink")
+        #expect(runner.pending.count == 4)
+        #expect(model.inFlight == 4)
+        #expect(model.hasFetched == false)
+
+        for call in runner.pending {
+            call.complete(response(for: call.domain, name: "Pink Floyd"))
+        }
+        await drainMainQueue()
+
+        #expect(model.artistResults.map(\.name) == ["Pink Floyd"])
+        #expect(model.albumResults.map(\.name) == ["Pink Floyd"])
+        #expect(model.inFlight == 0)
+        #expect(model.hasFetched == true)
+        #expect(model.allResultsEmpty == false)
+    }
+
+    @Test func staleResponsesAreDroppedAfterSecondSearch() async {
+        let runner = MockRunner()
+        let model = SearchResultsModel(runner: runner)
+
+        model.fireSearch(for: "first")
+        let firstBatch = runner.pending
+        #expect(firstBatch.count == 4)
+
+        // Second search fires before the first one's responses arrive.
+        model.fireSearch(for: "second")
+        #expect(runner.pending.count == 8)
+        #expect(model.inFlight == 4)  // reset per fan-out, not cumulative
+
+        // First search's responses arrive late — every one must be dropped.
+        for call in firstBatch {
+            call.complete(response(for: call.domain, name: "Stale"))
+        }
+        await drainMainQueue()
+
+        #expect(model.artistResults.isEmpty)
+        #expect(model.albumResults.isEmpty)
+        #expect(model.inFlight == 4)  // stale guard bails before completeOne
+        #expect(model.hasFetched == false)
+
+        // Second search's responses land normally.
+        for call in runner.pending.suffix(4) {
+            call.complete(response(for: call.domain, name: "Fresh"))
+        }
+        await drainMainQueue()
+
+        #expect(model.artistResults.map(\.name) == ["Fresh"])
+        #expect(model.albumResults.map(\.name) == ["Fresh"])
+        #expect(model.inFlight == 0)
+        #expect(model.hasFetched == true)
+    }
+
+    @Test func resetClearsResultsAndGates() async {
+        let runner = MockRunner()
+        let model = SearchResultsModel(runner: runner)
+
+        model.fireSearch(for: "pink")
+        for call in runner.pending {
+            call.complete(response(for: call.domain, name: "Pink Floyd"))
+        }
+        await drainMainQueue()
+        #expect(model.allResultsEmpty == false)
+
+        model.reset()
+        #expect(model.allResultsEmpty == true)
+        #expect(model.hasFetched == false)
+        #expect(model.inFlight == 0)
+
+        // A response surviving past reset() must also be dropped: reset is not
+        // a new token, but the next fireSearch issues one; simulate the common
+        // backspace-then-retype flow.
+        model.fireSearch(for: "queen")
+        let staleBatch = runner.pending.suffix(4)
+        model.reset()
+        model.fireSearch(for: "abba")
+        for call in staleBatch {
+            call.complete(response(for: call.domain, name: "Queen"))
+        }
+        await drainMainQueue()
+        #expect(model.artistResults.isEmpty)  // queen's responses were stale
+    }
+}

--- a/LMS_StreamTest/SlimProtoCoordinator.swift
+++ b/LMS_StreamTest/SlimProtoCoordinator.swift
@@ -2532,3 +2532,15 @@ extension SlimProtoCoordinator {
     var debugSyncController: SyncController { syncController }
 
 }
+
+// MARK: - JSON-RPC runner seam (98q.13)
+
+/// Single-method seam over the stateless JSON-RPC direct-command path.
+/// Views and models that only fire a query and parse the response depend on
+/// this instead of the full coordinator, so unit tests can inject a mock
+/// runner (delayed / out-of-order completions) — see SearchResultsModelTests.
+protocol SlimProtoJSONRPCRunner: AnyObject {
+    func sendJSONRPCCommandDirect(_ jsonRPC: [String: Any], completion: @escaping ([String: Any]) -> Void)
+}
+
+extension SlimProtoCoordinator: SlimProtoJSONRPCRunner {}


### PR DESCRIPTION
Implements bd issue **LMS_StreamTest-98q.13** (v2 follow-up from the 98q.8 plan-eng-review, D10 deferred). Opened as a draft by the autonomous pilot loop — human review + merge required.

## What

- **`SlimProtoJSONRPCRunner` protocol** (end of `SlimProtoCoordinator.swift`): single-method seam over `sendJSONRPCCommandDirect`; coordinator conforms via empty extension.
- **`SearchResultsModel`** (new): SearchView's 4-way fan-out + D5=B UUID cancellation token moved verbatim out of `@State` into an `ObservableObject` that takes the protocol. View keeps debounce, history, and drill-in covers.
- **`FavoritesView`**: property type switched to the protocol (only view that could switch cleanly).
- **`SearchResultsModelTests`** (new, Swift Testing): happy path, out-of-order stale-response race, reset. The mock captures completions so tests deliver them late and out of order — the exact race the token guards.

## Deviation from issue scope

The issue says to retrofit all 5 views to the protocol. **AlbumListView, PlaylistsView, and ArtistDetailView were intentionally left concrete**: each passes the coordinator to child views (`BuiltinTrackListView`, `JiveBrowseView`, …) that require the full `SlimProtoCoordinator`, and SearchView additionally calls `toggleLockScreenPlayPause()`. A literal retrofit would cascade into children outside the issue's file list. The testability goal is fully met via the model extraction.

## Test evidence

- `xcodebuild test -scheme LMS_StreamTest-tvOS -only-testing:LMS_StreamTest-tvOSTests`: **25 passed, 0 failed** (tvOS 26 simulator), including the 3 new tests.
- Adversarial review pass included a **mutation check**: deleting the token guard makes `staleResponsesAreDroppedAfterSecondSearch` and `resetClearsResultsAndGates` fail — the tests genuinely protect the guard.
- iOS Debug build verified green with the protocol compiled into the shared file.

## Follow-ups filed during review

- `LMS_StreamTest-ag7`: `reset()` doesn't rotate the token (pre-existing, preserved verbatim) — one-line fix + test scaffolding already in place.
- `LMS_StreamTest-39m`: tvOS UITests runner dlopen failure (CocoaAsyncSocket) makes full-scheme `xcodebuild test` report failure even when unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)