### PR TITLE
tvOS: repeat & shuffle controls on Now Playing (LMS_StreamTest-w53)

### DIFF
--- a/LMS_StreamTest-tvOS/NowPlayingView.swift
+++ b/LMS_StreamTest-tvOS/NowPlayingView.swift
@@ -18,6 +18,11 @@ struct NowPlayingView: View {
     @State private var scrubElapsed: Double = 0
     @State private var showVisualizer: Bool = false
     @State private var showQueue: Bool = false
+    // LMS playlist modes (w53). Synced from the server on appear / track change
+    // and after each toggle — same sync points CarPlay uses for its shuffle
+    // button (external toggles mid-screen reflect on the next track change).
+    @State private var shuffleMode: Int = 0   // 0=off, 1=songs, 2=albums
+    @State private var repeatMode: Int = 0    // 0=off, 1=one, 2=all
     @State private var didInitialFocus: Bool = false
     @FocusState private var playbackFocused: Bool
     @FocusState private var artworkFocused: Bool
@@ -53,6 +58,7 @@ struct NowPlayingView: View {
         .onAppear {
             tick()
             updateAccent()                                  // initial sample if artwork already loaded
+            syncPlaylistModes()
             // Defer focus assignment so SwiftUI focus engine has time to register focusable views.
             // Gate on didInitialFocus so re-appears (TabView tab switching) don't override
             // the focus state SwiftUI preserved between tab switches.
@@ -64,6 +70,9 @@ struct NowPlayingView: View {
             }
         }
         .onChange(of: nowPlaying.currentArtwork) { _, _ in updateAccent() }
+        // Track changes are the cheap re-sync point for repeat/shuffle toggled
+        // from another controller (Material web UI, iPhone) — w53.
+        .onChange(of: nowPlaying.currentTrackTitle) { _, _ in syncPlaylistModes() }
         .onReceive(Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()) { _ in tick() }
         .fullScreenCover(isPresented: $showVisualizer) {
             VisualizerView(accentColor: accentRGB,
@@ -375,7 +384,16 @@ struct NowPlayingView: View {
     // MARK: - Transport row
 
     private var transportRow: some View {
+        // shuffle | prev | play | next | repeat | queue (Apple Music ordering
+        // with the queue link kept rightmost, w53).
         HStack(spacing: 0) {
+            transportButton(
+                systemImage: "shuffle",
+                accessibilityLabel: shuffleAccessibilityLabel,
+                iconColor: shuffleMode != 0 ? accentColor : nil,
+                action: toggleShuffle
+            )
+            Spacer()
             transportButton(
                 systemImage: "backward.fill",
                 accessibilityLabel: "Previous Track",
@@ -394,12 +412,35 @@ struct NowPlayingView: View {
                 accessibilityLabel: "Next Track",
                 action: { sendCommand("next") }
             )
+            Spacer()
+            transportButton(
+                systemImage: repeatMode == 1 ? "repeat.1" : "repeat",
+                accessibilityLabel: repeatAccessibilityLabel,
+                iconColor: repeatMode != 0 ? accentColor : nil,
+                action: toggleRepeat
+            )
             if nowPlaying.hasTrackLoaded {
                 Spacer()
                 queueNavigationLink
             }
         }
         .padding(.horizontal, 24)
+    }
+
+    private var shuffleAccessibilityLabel: String {
+        switch shuffleMode {
+        case 1: return "Shuffle: Songs"
+        case 2: return "Shuffle: Albums"
+        default: return "Shuffle: Off"
+        }
+    }
+
+    private var repeatAccessibilityLabel: String {
+        switch repeatMode {
+        case 1: return "Repeat: One"
+        case 2: return "Repeat: All"
+        default: return "Repeat: Off"
+        }
     }
 
     private var queueNavigationLink: some View {
@@ -417,6 +458,7 @@ struct NowPlayingView: View {
         systemImage: String,
         accessibilityLabel: String,
         isPrimary: Bool = false,
+        iconColor: Color? = nil,
         action: @escaping () -> Void
     ) -> some View {
         CircleFocusButton(
@@ -424,6 +466,7 @@ struct NowPlayingView: View {
             accessibilityLabel: accessibilityLabel,
             diameter: isPrimary ? 88 : 72,
             iconSize: isPrimary ? 32 : 24,
+            iconColor: iconColor,
             action: action
         )
     }
@@ -510,6 +553,27 @@ struct NowPlayingView: View {
         coordinator.sendLockScreenCommand(command)
     }
 
+    // MARK: - Repeat / shuffle (w53)
+
+    private func syncPlaylistModes() {
+        coordinator.fetchPlaylistModes { repeatMode, shuffleMode in
+            self.repeatMode = repeatMode
+            self.shuffleMode = shuffleMode
+        }
+    }
+
+    private func toggleShuffle() {
+        coordinator.toggleShuffleMode { newMode in
+            DispatchQueue.main.async { shuffleMode = newMode }
+        }
+    }
+
+    private func toggleRepeat() {
+        coordinator.toggleRepeatMode { newMode in
+            DispatchQueue.main.async { repeatMode = newMode }
+        }
+    }
+
     // MARK: - Helpers
 
     private func formatTime(_ seconds: Double) -> String {
@@ -560,6 +624,8 @@ private struct CircleFocusButton: View {
     let accessibilityLabel: String
     let diameter: CGFloat
     let iconSize: CGFloat
+    /// Active-state tint (w53 repeat/shuffle). nil → standard primary icon.
+    var iconColor: Color? = nil
     let action: () -> Void
 
     @FocusState private var isFocused: Bool
@@ -584,7 +650,7 @@ private struct CircleFocusButton: View {
                     .strokeBorder(.white.opacity(isFocused ? 0.40 : 0), lineWidth: 2)
                 Image(systemName: systemImage)
                     .font(.system(size: iconSize, weight: .semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(iconColor ?? Color.primary)
             }
             .frame(width: diameter, height: diameter)
             .scaleEffect(isFocused ? 1.08 : 1.0)

--- a/LMS_StreamTest-tvOSTests/PlaylistModeCycleTests.swift
+++ b/LMS_StreamTest-tvOSTests/PlaylistModeCycleTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import LMS_StreamTest_tvOS
+
+/// Pins the LMS playlist-mode toggle orderings (w53). `toggleShuffleMode` and
+/// `toggleRepeatMode` route through these pure functions, so a regression here
+/// would silently change what the tvOS Now Playing buttons (and the CarPlay
+/// shuffle button) cycle to.
+struct PlaylistModeCycleTests {
+
+    @Test func shuffleCyclesOffSongsAlbumsOff() {
+        #expect(PlaylistModeCycle.nextShuffle(0) == 1)  // off → songs
+        #expect(PlaylistModeCycle.nextShuffle(1) == 2)  // songs → albums
+        #expect(PlaylistModeCycle.nextShuffle(2) == 0)  // albums → off
+    }
+
+    @Test func repeatCyclesOffAllOneOff() {
+        #expect(PlaylistModeCycle.nextRepeat(0) == 2)  // off → all
+        #expect(PlaylistModeCycle.nextRepeat(2) == 1)  // all → one
+        #expect(PlaylistModeCycle.nextRepeat(1) == 0)  // one → off
+    }
+
+    @Test func unknownModesRecoverIntoTheCycle() {
+        // A garbled server value must not strand the button — both cycles
+        // treat anything out of range as "off".
+        #expect(PlaylistModeCycle.nextShuffle(-1) == 1)
+        #expect(PlaylistModeCycle.nextShuffle(7) == 1)
+        #expect(PlaylistModeCycle.nextRepeat(-1) == 2)
+        #expect(PlaylistModeCycle.nextRepeat(7) == 2)
+    }
+
+    @Test func threePressesReturnToOff() {
+        var shuffle = 0
+        var repeatMode = 0
+        for _ in 0..<3 {
+            shuffle = PlaylistModeCycle.nextShuffle(shuffle)
+            repeatMode = PlaylistModeCycle.nextRepeat(repeatMode)
+        }
+        #expect(shuffle == 0)
+        #expect(repeatMode == 0)
+    }
+}

--- a/LMS_StreamTest/SlimProtoCoordinator.swift
+++ b/LMS_StreamTest/SlimProtoCoordinator.swift
@@ -1962,12 +1962,7 @@ extension SlimProtoCoordinator {
             }
 
             // Toggle to next state (0→1→2→0)
-            let newMode: Int
-            switch currentShuffle {
-            case 2: newMode = 0  // albums → off
-            case 1: newMode = 2  // songs → albums
-            default: newMode = 1  // off → songs
-            }
+            let newMode = PlaylistModeCycle.nextShuffle(currentShuffle)
 
             os_log(.info, log: self.logger, "🔀 Shuffle: %d → %d", currentShuffle, newMode)
 
@@ -1997,6 +1992,88 @@ extension SlimProtoCoordinator {
                     // Notify CarPlay to update button icon
                     completion?(newMode)
                 }
+            }
+        }
+    }
+
+    /// Toggles repeat mode through LMS's 3-state cycle: off→all→one→off
+    /// (Apple Music ordering). Called by the tvOS Now Playing repeat button (w53).
+    /// Mirrors toggleShuffleMode minus the MPRemoteCommandCenter update — no
+    /// iOS caller registers a repeat remote command yet.
+    /// - Parameter completion: Optional callback with the new repeat mode —
+    ///   value legend (not cycle order): 0=off, 2=all, 1=one
+    public func toggleRepeatMode(completion: ((Int) -> Void)? = nil) {
+        let playerID = settings.playerMACAddress
+
+        // Query current repeat state
+        let statusCommand: [String: Any] = [
+            "id": 1,
+            "method": "slim.request",
+            "params": [playerID, ["status", "-", 1, "tags:"]]
+        ]
+
+        os_log(.info, log: logger, "🔁 Repeat toggle requested...")
+
+        sendJSONRPCCommandDirect(statusCommand) { [weak self] response in
+            guard let self = self else { return }
+
+            let currentRepeat: Int
+            if let result = response["result"] as? [String: Any],
+               let repeatMode = result["playlist repeat"] as? Int {
+                currentRepeat = repeatMode
+            } else {
+                currentRepeat = 0
+                os_log(.info, log: self.logger, "⚠️ Could not read repeat state, defaulting to 0")
+            }
+
+            let newMode = PlaylistModeCycle.nextRepeat(currentRepeat)
+            os_log(.info, log: self.logger, "🔁 Repeat: %d → %d", currentRepeat, newMode)
+
+            let repeatCommand: [String: Any] = [
+                "id": 1,
+                "method": "slim.request",
+                "params": [playerID, ["playlist", "repeat", newMode]]
+            ]
+
+            self.sendJSONRPCCommandDirect(repeatCommand) { [weak self] repeatResponse in
+                guard let self = self else { return }
+                if !repeatResponse.isEmpty {
+                    os_log(.info, log: self.logger, "✅ Repeat mode set to %d", newMode)
+                    completion?(newMode)
+                }
+            }
+        }
+    }
+
+    /// Reads the player's current repeat + shuffle modes in one status query.
+    /// tvOS Now Playing syncs its button state with this on appear and on track
+    /// change (same query CarPlay's syncShuffleButtonWithServer fires for
+    /// shuffle alone). Completion runs on the main thread.
+    ///
+    /// On a failed/unparseable query the completion is NOT invoked — callers
+    /// keep their last known state. Fabricating (0, 0) here would paint mode
+    /// buttons "off" during a network blip and make the next tap cycle from
+    /// the wrong starting point.
+    /// - Parameter completion: (repeatMode, shuffleMode) per LMS values
+    ///   (repeat 0=off, 2=all, 1=one; shuffle 0=off, 1=songs, 2=albums).
+    public func fetchPlaylistModes(completion: @escaping (Int, Int) -> Void) {
+        let statusCommand: [String: Any] = [
+            "id": 1,
+            "method": "slim.request",
+            "params": [settings.playerMACAddress, ["status", "-", 1, "tags:"]]
+        ]
+
+        sendJSONRPCCommandDirect(statusCommand) { [weak self] response in
+            guard let result = response["result"] as? [String: Any] else {
+                if let self {
+                    os_log(.info, log: self.logger, "⚠️ Could not read playlist modes — keeping last known state")
+                }
+                return
+            }
+            let repeatMode = result["playlist repeat"] as? Int ?? 0
+            let shuffleMode = result["playlist shuffle"] as? Int ?? 0
+            DispatchQueue.main.async {
+                completion(repeatMode, shuffleMode)
             }
         }
     }
@@ -2531,4 +2608,27 @@ extension SlimProtoCoordinator {
     /// Debug snapshot for Phase 2 verification harness.
     var debugSyncController: SyncController { syncController }
 
+}
+
+// MARK: - Playlist mode cycles (w53)
+
+/// LMS playlist-mode toggle orderings, pure so unit tests can pin them:
+/// - shuffle: 0 off → 1 songs → 2 albums → 0 (pre-existing toggleShuffleMode order)
+/// - repeat:  0 off → 2 all → 1 one → 0 (Apple Music ordering)
+enum PlaylistModeCycle {
+    static func nextShuffle(_ current: Int) -> Int {
+        switch current {
+        case 1: return 2   // songs → albums
+        case 2: return 0   // albums → off
+        default: return 1  // off (or unknown) → songs
+        }
+    }
+
+    static func nextRepeat(_ current: Int) -> Int {
+        switch current {
+        case 2: return 1   // all → one
+        case 1: return 0   // one → off
+        default: return 2  // off (or unknown) → all
+        }
+    }
 }


### PR DESCRIPTION
Implements bd issue **LMS_StreamTest-w53** (Elissen #6, GH #83). Opened as a draft by the autonomous pilot loop — human review + merge required. **Visuals need a hardware pass** (accent tint + focus behavior on a real TV).

## What

- **Transport row**: `shuffle | prev | play | next | repeat | queue` (Apple Music ordering). New buttons reuse `CircleFocusButton` with a new optional `iconColor` — artwork-accent tint when the mode is active; repeat-one swaps to the `repeat.1` symbol. Accessibility labels carry the precise mode ("Shuffle: Albums", "Repeat: One").
- **Coordinator** (shared file): `toggleRepeatMode` mirroring the existing CarPlay-proven `toggleShuffleMode` (repeat cycle off→all→one, Apple Music ordering); `fetchPlaylistModes` for one-query state sync (completion on main; **not invoked on failure** so the UI keeps last known state). Both cycles now route through a pure `PlaylistModeCycle` enum.
- **Sync points**: on appear, on track-title change, and after each toggle — same model as CarPlay's shuffle button. External toggles mid-screen reflect at the next track change.
- **Tests**: `PlaylistModeCycleTests` (4 tests) pin both cycle orderings, unknown-value recovery, and cycle length.

## Design choices for reviewer

- Shuffle songs-vs-albums is distinguished by accessibility label only in v1 (no SF symbol for shuffle-by-album; tint covers active/inactive). Add a badge later if hardware review wants it.
- Toggle-vs-sync last-write-wins race exists (display-only, self-corrects at next sync) — same model CarPlay ships today; flagged by review as acceptable.

## Test evidence

- tvOS unit tests: **31 passed, 0 failed** (includes the 4 new cycle tests).
- iOS Debug build: **succeeded** (shared `SlimProtoCoordinator.swift` changed; `toggleShuffleMode` refactor verified behavior-identical by adversarial review).
- Adversarial review: no blockers; its one should-fix (failed status query fabricating "off" state) is fixed in this PR.

## Noted, not touched

`NowPlayingView.private var content` (~line 102) appears to be pre-existing dead code — left alone per repo rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)