### PR TITLE
Playback smoke harness v0 — LMS server as test oracle (LMS_StreamTest-6b1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ test-content/
 
 # Experimental scratch (LMS convert.conf snippets, etc. — share manually, not via git)
 experimental/
+
+# Python bytecode (smoke harness)
+__pycache__/

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -1,0 +1,102 @@
+# Playback Smoke-Test Harness — LMS Server as Test Oracle
+
+**Status**: v0 implemented (this directory). bd epic `LMS_StreamTest-6b1`; v1
+(OSLog correlation) and v2 (lifecycle/device scenarios) tracked as children.
+
+## Why
+
+Manual listening is the verification bottleneck for this project. But LyrPlay is a
+SlimProto client of an *observable server*: nearly every playback behavior is mirrored
+in LMS state that is queryable over JSON-RPC. A healthy audio pipeline shows up as
+machine-checkable signals — no ears, no audio capture:
+
+- the player is registered and `connected`
+- `mode` is `play`
+- `time` advances monotonically at ~1x wall clock
+- `playlist_cur_index` changes at the expected track boundary, not early or late
+
+Historical shipped bugs map directly onto these signals:
+
+| Bug class | Oracle signal that catches it |
+|---|---|
+| Gapless early-jump (LMS_StreamTest-sfk) | index advances tens of seconds before the boundary |
+| Silent playback after interruption (u7h) | `mode == play` but `time` frozen (stall watchdog) |
+| Recovery lands at wrong track/position | post-recovery `playlist_cur_index`/`time` ≠ saved values (v2) |
+| Player never reconnects | player absent from `serverstatus.players_loop` |
+
+What the oracle **cannot** catch: audible glitches (clicks at gapless seams, 100ms
+audio bursts), CarPlay hardware behavior, real phone-call interruptions. Those stay
+human-verified.
+
+## Usage
+
+```bash
+scripts/smoke/run.sh             # build, boot sim, launch app, all scenarios
+scripts/smoke/run.sh S1 S5       # a subset
+python3 scripts/smoke/smoke.py   # scenarios only (app already running)
+```
+
+`run.sh` builds the iOS app (incremental, cached DerivedData in
+`~/Library/Developer/Xcode/DerivedData/LyrPlay-smoke` — deliberately outside the
+repo: the repo lives under `Documents/`, where iCloud's Finder metadata breaks
+codesign), boots the simulator, pre-seeds UserDefaults so the app launches
+already configured against the test server, and runs the scenarios. Exit
+nonzero on any failure.
+
+Env knobs (defaults): `LYRPLAY_LMS_HOST` (192.168.1.8), `LYRPLAY_LMS_PORT`
+(9000), `LYRPLAY_SLIM_PORT` (3483), `LYRPLAY_SIM_NAME` (iPhone 17),
+`LYRPLAY_PLAYER_NAME` (SmokeTest Player), `LYRPLAY_PLAYER_ID` (skips
+discovery), `LYRPLAY_SOAK_SECONDS` (60), `LYRPLAY_APP_PATH` (prebuilt .app,
+skips the build).
+
+## Scenarios — v0
+
+Test content is selected from the server library at run time (no hardcoded
+IDs): an album with ≥ 2 tracks, an opening track of 20–300s (true track order
+via `sort:tracknum`), and at least one track ≥ 45s for the seek proof.
+
+| ID | Scenario | Pass criteria |
+|---|---|---|
+| S1 | register & play | player discovered by name ≤ 30s; album loads; mode=play; time advancing at 1x ±0.15 after buffering settles |
+| S2 | pause/resume | time frozen (±0.5s over 3s) while paused; single post-resume sample within [-0.5, +4.0]s of the pause position (catches restart-at-0; pause taken ≥ 5s in so the cases are distinguishable) |
+| S3 | skip next/prev | index +1 with time restarting < 3s; index -1; advancing after |
+| S4 | seek | **provable** forward jump: +25s from the playhead on a ≥ 45s track — bigger than natural playback can sweep within the 8s poll window, so a matched position proves the seek |
+| S5 | gapless boundary | seek to duration−15 on track 0; index 0→1 within an effective **−4s/+10s** window of the boundary (tighter risks false fails from LMS server-side time interpolation; the sfk class fires ~30s early and is caught decisively); next track advancing after |
+| S6 | stall soak | 60s (configurable) of mode=play with time at ~1x; track boundaries mid-window tolerated (bounded re-measure, max 3) |
+
+Notes on intent vs. mechanics:
+
+- **Stall watchdog** is not a background thread; it's `assert_time_advancing`,
+  called explicitly in every scenario. A stall during an index-wait surfaces
+  as that scenario's timeout instead.
+- Scenarios share player state (the loaded album) for speed; `ensure_playing`
+  re-establishes the baseline so any subset is still runnable.
+- `wait_until_advancing` separates re-buffering after loads/jumps/seeks from
+  genuine stalls — without it, the first measurement window after any stream
+  restart reads ~0.5x and false-fails.
+
+## Architecture
+
+```
+run.sh   — build (always; stale binaries must never get certified),
+           boot sim (newest runtime for the device name),
+           pre-seed UserDefaults (keys/types match SettingsManager.Keys),
+           install + launch, then exec smoke.py
+smoke.py — Oracle (JSON-RPC client + assertion vocabulary),
+           pick_album (runtime test-content selection),
+           scenarios S1–S6, pass/fail table, exit code
+```
+
+Python 3 stdlib only; no new dependencies.
+
+## Roadmap
+
+- **v1 — log correlation** (`LMS_StreamTest-6b1.2`): stream OSLog (subsystem
+  `com.lmsstream`) during scenarios; dump tail on failure; assert no
+  error-level audio logs during passing scenarios.
+- **v2 — lifecycle & device** (`LMS_StreamTest-6b1.3`): background >45s
+  recovery, route change, interruption. Simulator can background the app;
+  lock screen and real interruptions need a USB device (wiki:
+  `Setup/iPhone Build Workflow.md`). Recovery assertions: post-recovery
+  `playlist_cur_index`/`time` match saved pre-background values
+  (`performPlaylistRecovery()` end-to-end).

--- a/scripts/smoke/run.sh
+++ b/scripts/smoke/run.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# LyrPlay playback smoke harness (v0) — boots an iOS simulator, installs the
+# app preconfigured for the test LMS server, launches it, and runs the
+# JSON-RPC oracle scenarios in smoke.py.
+#
+# Spec: docs/playback-smoke-harness.md (bd epic LMS_StreamTest-6b1).
+#
+#   scripts/smoke/run.sh             # all scenarios
+#   scripts/smoke/run.sh S1 S5       # subset
+#
+# Env overrides:
+#   LYRPLAY_LMS_HOST   (192.168.1.8)   LYRPLAY_LMS_PORT  (9000)
+#   LYRPLAY_SLIM_PORT  (3483)          LYRPLAY_SIM_NAME  (iPhone 17 — must
+#                                      exist on the LATEST installed runtime)
+#   LYRPLAY_PLAYER_NAME (SmokeTest Player)
+#   LYRPLAY_APP_PATH   prebuilt .app — skips the xcodebuild step
+#
+# The Debug build is cached in build/smoke-derived-data; delete it to force
+# a rebuild after app-code changes.
+set -euo pipefail
+
+LMS_HOST="${LYRPLAY_LMS_HOST:-192.168.1.8}"
+LMS_PORT="${LYRPLAY_LMS_PORT:-9000}"
+SLIM_PORT="${LYRPLAY_SLIM_PORT:-3483}"
+SIM_NAME="${LYRPLAY_SIM_NAME:-iPhone 17}"
+PLAYER_NAME="${LYRPLAY_PLAYER_NAME:-SmokeTest Player}"
+BUNDLE_ID="elm.LMS-StreamTest"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# DerivedData must live OUTSIDE the repo: the repo sits under Documents/, where
+# iCloud adds Finder metadata to new files and codesign then rejects the
+# embedded frameworks ("resource fork ... detritus not allowed").
+DD="${LYRPLAY_SMOKE_DD:-$HOME/Library/Developer/Xcode/DerivedData/LyrPlay-smoke}"
+APP="${LYRPLAY_APP_PATH:-$DD/Build/Products/Debug-iphonesimulator/LMS_StreamTest.app}"
+
+echo "== LyrPlay smoke harness: $SIM_NAME vs LMS $LMS_HOST:$LMS_PORT =="
+
+# 1. Build the app — ALWAYS (incremental via cached DerivedData, so cheap when
+#    nothing changed). Skipping on .app existence would certify a stale binary,
+#    the worst failure mode for a harness gating fix loops. LYRPLAY_APP_PATH
+#    opts out for prebuilt bundles.
+if [ -z "${LYRPLAY_APP_PATH:-}" ]; then
+  echo "-- building LMS_StreamTest (Debug, simulator)..."
+  BUILD_LOG="$(mktemp -t lyrplay-smoke-build)"
+  if ! xcodebuild -workspace "$ROOT/LMS_StreamTest.xcworkspace" -scheme LMS_StreamTest \
+      -configuration Debug -destination "platform=iOS Simulator,name=$SIM_NAME" \
+      -derivedDataPath "$DD" build > "$BUILD_LOG" 2>&1; then
+    echo "-- BUILD FAILED ($BUILD_LOG):"
+    grep -m 8 "error:" "$BUILD_LOG" || tail -15 "$BUILD_LOG"
+    exit 1
+  fi
+fi
+[ -d "$APP" ] || { echo "app bundle not found at $APP"; exit 1; }
+
+# 2. Boot the simulator
+# Prefer the NEWEST runtime when the same device name exists on several —
+# xcodebuild's implicit OS:latest resolves the same way, keeping build and
+# boot on the same runtime.
+UDID=$(xcrun simctl list -j devices available | SIM_NAME="$SIM_NAME" python3 -c "
+import json, os, sys
+data = json.load(sys.stdin)
+matches = [
+    (runtime, dev['udid'])
+    for runtime, devs in data['devices'].items()
+    for dev in devs
+    if dev['name'] == os.environ['SIM_NAME']
+]
+if not matches:
+    sys.exit('no available simulator named ' + os.environ['SIM_NAME'])
+print(max(matches)[1])
+")
+echo "-- simulator: $SIM_NAME ($UDID)"
+xcrun simctl bootstatus "$UDID" -b >/dev/null
+
+# 3. Pre-seed UserDefaults so the app skips onboarding and connects straight
+#    to the test server. Keys/types must match SettingsManager.Keys.
+xcrun simctl spawn "$UDID" defaults write "$BUNDLE_ID" ServerHost -string "$LMS_HOST"
+xcrun simctl spawn "$UDID" defaults write "$BUNDLE_ID" ServerWebPort -int "$LMS_PORT"
+xcrun simctl spawn "$UDID" defaults write "$BUNDLE_ID" ServerSlimProtoPort -int "$SLIM_PORT"
+xcrun simctl spawn "$UDID" defaults write "$BUNDLE_ID" PlayerName -string "$PLAYER_NAME"
+# SettingsVersion deliberately NOT seeded: absent (0) is the app's benign
+# first-launch path; a hardcoded literal would silently diverge when the app
+# bumps currentSettingsVersion.
+xcrun simctl spawn "$UDID" defaults write "$BUNDLE_ID" IsConfigured -bool YES
+
+# 4. Install + fresh launch
+xcrun simctl install "$UDID" "$APP"
+xcrun simctl terminate "$UDID" "$BUNDLE_ID" 2>/dev/null || true
+xcrun simctl launch "$UDID" "$BUNDLE_ID" >/dev/null
+echo "-- app launched, running scenarios"
+
+# 5. Oracle scenarios (exit code propagates)
+LYRPLAY_LMS_HOST="$LMS_HOST" LYRPLAY_LMS_PORT="$LMS_PORT" \
+LYRPLAY_PLAYER_NAME="$PLAYER_NAME" \
+  python3 "$ROOT/scripts/smoke/smoke.py" "$@"

--- a/scripts/smoke/smoke.py
+++ b/scripts/smoke/smoke.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""LyrPlay playback smoke harness — LMS server as test oracle (v0).
+
+Spec: scripts/smoke/README.md (bd epic LMS_StreamTest-6b1).
+
+Asserts playback health from LMS JSON-RPC state alone: player registered,
+mode, time advancing at ~1x wall clock, playlist index changing at expected
+track boundaries. No audio capture — audible quality stays human-verified.
+
+Usually invoked via scripts/smoke/run.sh (which boots the simulator and
+launches a preconfigured app). Run directly when the app is already up:
+
+    python3 scripts/smoke/smoke.py            # all scenarios
+    python3 scripts/smoke/smoke.py S1 S5      # a subset
+
+Env:
+    LYRPLAY_LMS_HOST      LMS host (default 192.168.1.8)
+    LYRPLAY_LMS_PORT      LMS HTTP port (default 9000)
+    LYRPLAY_PLAYER_NAME   player name to discover (default "SmokeTest Player")
+    LYRPLAY_PLAYER_ID     player MAC — skips name discovery
+    LYRPLAY_SOAK_SECONDS  S6 soak duration (default 60)
+
+Exit code 0 = all selected scenarios passed.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+
+LMS_HOST = os.environ.get("LYRPLAY_LMS_HOST", "192.168.1.8")
+LMS_PORT = int(os.environ.get("LYRPLAY_LMS_PORT", "9000"))
+PLAYER_NAME = os.environ.get("LYRPLAY_PLAYER_NAME", "SmokeTest Player")
+PLAYER_ID = os.environ.get("LYRPLAY_PLAYER_ID", "")
+SOAK_SECONDS = int(os.environ.get("LYRPLAY_SOAK_SECONDS", "60"))
+
+POLL_INTERVAL = 0.5
+
+
+class CheckFailed(Exception):
+    pass
+
+
+class Oracle:
+    """Minimal JSON-RPC client for LMS + the assertion vocabulary from the spec."""
+
+    def __init__(self, host, port):
+        self.url = f"http://{host}:{port}/jsonrpc.js"
+        self.player_id = PLAYER_ID
+
+    def rpc(self, cmd, player=""):
+        body = json.dumps(
+            {"id": 1, "method": "slim.request", "params": [player, cmd]}
+        ).encode()
+        req = urllib.request.Request(
+            self.url, data=body, headers={"Content-Type": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.load(resp).get("result", {})
+
+    def player_rpc(self, cmd):
+        return self.rpc(cmd, player=self.player_id)
+
+    # -- discovery ---------------------------------------------------------
+
+    def discover(self, name, timeout=30):
+        """Find the player by name in serverstatus; sets self.player_id.
+        Transient network errors consume the timeout budget instead of crashing."""
+        deadline = time.time() + timeout
+        seen, last_err = [], None
+        while time.time() < deadline:
+            try:
+                players = self.rpc(["serverstatus", 0, 99]).get("players_loop", [])
+            except OSError as e:
+                last_err = e
+                time.sleep(1)
+                continue
+            seen = [(p.get("name"), p.get("playerid"), p.get("connected")) for p in players]
+            for p in players:
+                if p.get("name") == name and p.get("connected"):
+                    self.player_id = p["playerid"]
+                    return self.player_id
+            time.sleep(1)
+        raise CheckFailed(
+            f"player named {name!r} not connected within {timeout}s; "
+            f"saw: {seen}" + (f"; last error: {last_err}" if last_err else "")
+        )
+
+    # -- state -------------------------------------------------------------
+
+    def status(self):
+        """mode / time / duration / playlist index / track count, one query."""
+        r = self.player_rpc(["status", "-", 1, "tags:d"])
+        return {
+            "mode": r.get("mode", "?"),
+            "time": float(r.get("time", 0) or 0),
+            "duration": float(r.get("duration", 0) or 0),
+            "index": int(r.get("playlist_cur_index", -1)),
+            "tracks": int(r.get("playlist_tracks", 0)),
+        }
+
+    def playlist_durations(self):
+        """Per-track durations of the loaded playlist, in true playlist order."""
+        loop = self.player_rpc(["status", 0, 99, "tags:d"]).get("playlist_loop", [])
+        return [float(t.get("duration", 0) or 0) for t in loop]
+
+    # -- assertions (spec: scripts/smoke/README.md) --------------------------
+
+    def assert_mode(self, expected):
+        mode = self.status()["mode"]
+        if mode != expected:
+            raise CheckFailed(f"mode is {mode!r}, expected {expected!r}")
+
+    def assert_time_advancing(self, window=5.0, lo=0.85, hi=1.15, _retries=3):
+        """time must advance at ~1x wall clock over the window. Doubles as the
+        stall watchdog: mode==play with frozen time fails here (u7h class)."""
+        for attempt in range(_retries):
+            s0, w0 = self.status(), time.time()
+            time.sleep(window)
+            s1, w1 = self.status(), time.time()
+            rate = (s1["time"] - s0["time"]) / (w1 - w0)
+            if lo <= rate <= hi:
+                return
+            # A track boundary inside the window resets time — measure again
+            # (bounded; a stalled player has a stable index and fails below).
+            if rate < lo and s1["index"] != s0["index"] and attempt < _retries - 1:
+                continue
+            raise CheckFailed(
+                f"time rate {rate:.2f}x over {window}s window "
+                f"({s0['time']:.1f}s → {s1['time']:.1f}s), expected ~1x"
+            )
+
+    def assert_time_frozen(self, window=3.0, tolerance=0.5):
+        t0 = self.status()["time"]
+        time.sleep(window)
+        t1 = self.status()["time"]
+        if abs(t1 - t0) > tolerance:
+            raise CheckFailed(f"time moved {t0:.1f}s → {t1:.1f}s while paused")
+
+    def assert_index(self, expected, timeout=5.0):
+        deadline = time.time() + timeout
+        idx = None
+        while time.time() < deadline:
+            idx = self.status()["index"]
+            if idx == expected:
+                return
+            time.sleep(POLL_INTERVAL)
+        raise CheckFailed(f"playlist index is {idx}, expected {expected}")
+
+    def assert_position(self, target, tolerance=2.0, timeout=8.0):
+        """Poll until the playhead is at target. NOTE: a playing track sweeps
+        through every position, so this alone cannot prove a SEEK happened —
+        only that the playhead ended up there. Seek proof lives in s4_seek
+        (forward jump bigger than the poll window can sweep)."""
+        deadline = time.time() + timeout
+        t = None
+        while time.time() < deadline:
+            t = self.status()["time"]
+            if abs(t - target) <= tolerance:
+                return
+            time.sleep(POLL_INTERVAL)
+        raise CheckFailed(f"position {t:.1f}s, expected {target:.1f}±{tolerance}s")
+
+    def wait_until_advancing(self, timeout=12.0):
+        """Block until playback time is actually moving — loads, jumps and
+        seeks re-buffer the stream for a few seconds, which would otherwise
+        pollute the first rate-measurement window."""
+        deadline = time.time() + timeout
+        prev = self.status()["time"]
+        while time.time() < deadline:
+            time.sleep(1.0)
+            cur = self.status()["time"]
+            if cur - prev >= 0.8:
+                return
+            prev = cur
+        raise CheckFailed(f"playback did not start advancing within {timeout}s")
+
+
+# -- test playlist ----------------------------------------------------------
+
+
+def pick_album(oracle):
+    """Choose a library album with >= 2 tracks whose OPENING track (true track
+    order, sort:tracknum) is short enough for a fast S5 boundary test, and
+    which contains at least one track >= 45s for S4's provable seek.
+    No hardcoded IDs — works against any populated server."""
+    titles = oracle.rpc(["titles", 0, 500, "tags:de"]).get("titles_loop", [])
+    albums = {}
+    for t in titles:
+        album_id = t.get("album_id")
+        if album_id is not None:
+            albums.setdefault(album_id, []).append(float(t.get("duration", 0) or 0))
+    candidates = sorted(
+        (a for a, d in albums.items() if len(d) >= 2 and max(d) >= 45),
+        key=lambda a: sum(sorted(albums[a])[:2]),
+    )
+    for album_id in candidates[:10]:
+        ordered = oracle.rpc(
+            ["titles", 0, 2, "tags:d", "sort:tracknum", f"album_id:{album_id}"]
+        ).get("titles_loop", [])
+        if len(ordered) >= 2 and 20 <= float(ordered[0].get("duration", 0) or 0) <= 300:
+            return album_id
+    raise CheckFailed(
+        "no suitable album in the first 500 library titles "
+        "(need >= 2 tracks, opening track 20-300s, one track >= 45s)"
+    )
+
+
+def load_album(oracle, album_id):
+    """Load the album (auto-plays) and wait for playback to register."""
+    oracle.player_rpc(["playlistcontrol", "cmd:load", f"album_id:{album_id}"])
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        s = oracle.status()
+        if s["mode"] == "play" and s["tracks"] >= 2:
+            return s
+        time.sleep(POLL_INTERVAL)
+    raise CheckFailed(f"album {album_id} did not start playing within 10s: {oracle.status()}")
+
+
+def ensure_playing(oracle, album_id):
+    s = oracle.status()
+    if s["tracks"] < 2:
+        return load_album(oracle, album_id)
+    if s["mode"] != "play":
+        oracle.player_rpc(["play"])
+        time.sleep(1)
+    return oracle.status()
+
+
+# -- scenarios ---------------------------------------------------------------
+
+
+def s1_register_and_play(oracle, album_id):
+    """Cold registration + first playback."""
+    load_album(oracle, album_id)
+    oracle.assert_mode("play")
+    oracle.wait_until_advancing()  # initial buffering is not a stall
+    oracle.assert_time_advancing(window=5.0)
+
+
+def s2_pause_resume(oracle, album_id):
+    ensure_playing(oracle, album_id)
+    oracle.wait_until_advancing()
+    # Get the playhead clear of 0 so a restart-from-start bug on resume is
+    # distinguishable from a correct resume.
+    deadline = time.time() + 30
+    while oracle.status()["time"] < 5.0 and time.time() < deadline:
+        time.sleep(1.0)
+    oracle.player_rpc(["pause", "1"])
+    time.sleep(0.5)
+    oracle.assert_mode("pause")
+    oracle.assert_time_frozen(window=3.0)
+    pause_at = oracle.status()["time"]
+    oracle.player_rpc(["pause", "0"])
+    # Single post-settle sample, NOT a sweep-poll: a track restarted at 0
+    # would land near 2.5s here, outside the window for any pause_at >= 5.
+    time.sleep(2.5)
+    t = oracle.status()["time"]
+    if not (pause_at - 0.5 <= t <= pause_at + 4.0):
+        raise CheckFailed(f"resume landed at {t:.1f}s, expected ~{pause_at:.1f}s")
+    oracle.assert_time_advancing(window=4.0)
+
+
+def s3_skip(oracle, album_id):
+    ensure_playing(oracle, album_id)
+    oracle.player_rpc(["playlist", "index", 0])
+    oracle.assert_index(0)
+    oracle.player_rpc(["playlist", "index", "+1"])
+    oracle.assert_index(1)
+    oracle.assert_position(0, tolerance=3.0)  # new track starts near 0
+    oracle.player_rpc(["playlist", "index", "-1"])
+    oracle.assert_index(0)
+    oracle.wait_until_advancing()
+    oracle.assert_time_advancing(window=4.0)
+
+
+def s4_seek(oracle, album_id):
+    """Seek must move the playhead DISCONTINUOUSLY. The forward jump (+25s) is
+    bigger than natural playback can sweep within the 8s poll window, so a
+    matched position proves the seek happened (review F-blocker fix)."""
+    ensure_playing(oracle, album_id)
+    durations = oracle.playlist_durations()
+    longest = max(range(len(durations)), key=lambda i: durations[i])
+    if durations[longest] < 45:
+        raise CheckFailed(f"no track >= 45s in test playlist ({durations})")
+    oracle.player_rpc(["playlist", "index", longest])
+    oracle.assert_index(longest)
+    oracle.wait_until_advancing()
+    t0 = oracle.status()["time"]
+    target = t0 + 25.0
+    if target > durations[longest] - 10:
+        raise CheckFailed(
+            f"playhead {t0:.0f}s too deep in {durations[longest]:.0f}s track for +25s seek"
+        )
+    oracle.player_rpc(["time", target])
+    oracle.assert_position(target, tolerance=2.5)
+    oracle.wait_until_advancing()  # seek re-buffers like any stream restart
+    oracle.assert_time_advancing(window=4.0)
+
+
+def s5_gapless_boundary(oracle, album_id):
+    """Track must flip to the NEXT index at the duration boundary — not tens of
+    seconds early (the sfk bug class) and not stall. Effective window is
+    -4s/+10s around the boundary: tighter risks false fails from LMS
+    server-side time interpolation (see README)."""
+    ensure_playing(oracle, album_id)
+    oracle.player_rpc(["playlist", "index", 0])
+    oracle.assert_index(0)
+    oracle.wait_until_advancing()
+    duration = oracle.status()["duration"]
+    if duration < 20:
+        raise CheckFailed(f"track 0 too short for boundary test ({duration}s)")
+    lead_in = 15.0
+    oracle.player_rpc(["time", duration - lead_in])
+    oracle.assert_position(duration - lead_in, tolerance=2.5)
+    started = time.time()
+    deadline = started + lead_in + 10
+    while time.time() < deadline:
+        s = oracle.status()
+        if s["index"] == 1:
+            elapsed = time.time() - started
+            if elapsed < lead_in - 4.0:
+                raise CheckFailed(
+                    f"boundary fired {lead_in - elapsed:.1f}s EARLY "
+                    f"(after {elapsed:.1f}s, expected ~{lead_in:.0f}s) — sfk class"
+                )
+            oracle.wait_until_advancing()  # next track actually playing
+            return
+        if s["index"] not in (0, 1):
+            raise CheckFailed(f"index jumped to {s['index']}, expected 0→1")
+        time.sleep(POLL_INTERVAL)
+    raise CheckFailed(f"no track boundary within {lead_in + 10:.0f}s — stalled at {oracle.status()}")
+
+
+def s6_soak(oracle, album_id):
+    """mode stays play and time keeps advancing, unattended."""
+    ensure_playing(oracle, album_id)
+    oracle.player_rpc(["playlist", "index", 0])
+    oracle.wait_until_advancing()  # jump re-buffers; don't count that as a stall
+    remaining = SOAK_SECONDS
+    while remaining > 0:
+        chunk = min(10.0, remaining)
+        oracle.assert_time_advancing(window=chunk)
+        remaining -= chunk
+
+
+SCENARIOS = [
+    ("S1", "register & play", s1_register_and_play),
+    ("S2", "pause/resume", s2_pause_resume),
+    ("S3", "skip next/prev", s3_skip),
+    ("S4", "seek", s4_seek),
+    ("S5", "gapless boundary", s5_gapless_boundary),
+    ("S6", f"stall soak ({SOAK_SECONDS}s)", s6_soak),
+]
+
+
+def main():
+    known = {sid for sid, _, _ in SCENARIOS}
+    selected = set(a.upper() for a in sys.argv[1:]) or known
+    unknown = selected - known
+    if unknown:
+        print(f"unknown scenario(s): {', '.join(sorted(unknown))} — "
+              f"choose from {', '.join(sorted(known))}")
+        return 2
+
+    oracle = Oracle(LMS_HOST, LMS_PORT)
+    try:
+        if not oracle.player_id:
+            print(f"discovering player {PLAYER_NAME!r} on {LMS_HOST}:{LMS_PORT} ...")
+            oracle.discover(PLAYER_NAME)
+        print(f"player: {oracle.player_id}")
+        album_id = pick_album(oracle)
+        print(f"test album: {album_id}\n")
+    except (CheckFailed, OSError) as e:
+        print(f"SETUP FAILED — {e}")
+        return 1
+
+    results = []
+    for sid, label, fn in SCENARIOS:
+        if sid not in selected:
+            continue
+        try:
+            fn(oracle, album_id)
+            results.append((sid, label, "PASS", ""))
+        except CheckFailed as e:
+            results.append((sid, label, "FAIL", str(e)))
+        except Exception as e:  # network errors etc. — fail the scenario, keep going
+            results.append((sid, label, "FAIL", f"{type(e).__name__}: {e}"))
+        print(f"{sid} {label:<24} {results[-1][2]}"
+              + (f"  — {results[-1][3]}" if results[-1][3] else ""))
+
+    try:
+        oracle.player_rpc(["stop"])
+    except Exception:
+        pass  # teardown must never eat the report
+
+    failed = [r for r in results if r[2] == "FAIL"]
+    print(f"\n{len(results) - len(failed)}/{len(results)} scenarios passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements bd issue **LMS_StreamTest-6b1.1** (epic `6b1`). Opened as a draft by the autonomous pilot loop — human review + merge required. **Zero app code changed** — this is test infrastructure only (`scripts/smoke/` + a `.gitignore` line).

## What

End-to-end playback verification without ears: `run.sh` builds the app, boots a simulator, pre-seeds UserDefaults (keys/types verified against `SettingsManager.Keys`) so the app launches already connected to the test LMS as "SmokeTest Player", then `smoke.py` discovers the player over JSON-RPC and asserts server-side playback state. Python 3 stdlib only. Spec ships as `scripts/smoke/README.md`.

| Scenario | Catches |
|---|---|
| S1 register & play | connection/registration failures |
| S2 pause/resume | restart-at-0 resume bugs (single post-settle sample — sweep-polling would be vacuous) |
| S3 skip next/prev | playlist index handling |
| S4 provable seek | +25s forward jump, bigger than the poll window can sweep — a matched position proves the seek |
| S5 gapless boundary | the `sfk` early-jump class (index flipping tens of seconds before the boundary) |
| S6 stall soak | the `u7h` silent-playback class (mode=play, time frozen) |

## Test evidence

Validated live against LMS 9.1.0 (192.168.1.8), iPhone 17 simulator: **6/6 scenarios pass**. The harness earned its keep during its own development — it caught and forced fixes for: iCloud-DerivedData breaking codesign, post-jump/post-seek re-buffering reading as stalls, and (via adversarial review + live confirmation) a vacuous-position-assertion blocker.

## Adversarial review

Full review applied: vacuous-assertion blocker fixed (S2/S4 redesigned), always-build so a stale binary can never get certified, bounded boundary-retry, guarded teardown, transient-error-tolerant discovery, true-track-order album selection, newest-runtime simulator pick. Spec relocated from gitignored `docs/` to `scripts/smoke/README.md`.

## Notes for reviewer

- Machine-level observation: builds/IO under the iCloud-synced `Documents/` repo path stall intermittently (three hangs during validation). DerivedData is kept outside the repo for this reason; consider whether the repo should live outside iCloud.
- v1 (OSLog correlation) and v2 (lifecycle/device scenarios incl. background-recovery assertions) are tracked as `6b1.2` / `6b1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)