### PR TITLE
Add https support (solves #98)

### DIFF
--- a/LMS_StreamTest/AppDelegate.swift
+++ b/LMS_StreamTest/AppDelegate.swift
@@ -173,10 +173,8 @@ class SiriMediaHandler: NSObject, INPlayMediaIntentHandling {
 
     private func sendJSONRPC(_ command: [String: Any], completion: @escaping ([String: Any]?) -> Void) {
         let settings = SettingsManager.shared
-        let host = settings.activeServerHost
-        let port = settings.activeServerWebPort
 
-        guard let url = URL(string: "http://\(host):\(port)/jsonrpc.js") else {
+        guard let url = URL(string: settings.buildURLString(path: "/jsonrpc.js")) else {
             completion(nil)
             return
         }

--- a/LMS_StreamTest/AppDelegate.swift
+++ b/LMS_StreamTest/AppDelegate.swift
@@ -196,7 +196,7 @@ class SiriMediaHandler: NSObject, INPlayMediaIntentHandling {
             return
         }
 
-        URLSession.shared.dataTask(with: request) { data, _, error in
+        URLSession.lms.dataTask(with: request) { data, _, error in
             guard let data = data, error == nil,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 completion(nil)

--- a/LMS_StreamTest/CarPlaySceneDelegate.swift
+++ b/LMS_StreamTest/CarPlaySceneDelegate.swift
@@ -901,7 +901,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPN
 
         let settings = SettingsManager.shared
         // Request 200x200 thumbnail for CarPlay list views — full-res is too slow
-        let urlString = "http://\(settings.activeServerHost):\(settings.activeServerWebPort)/music/\(coverID)/cover_200x200_o.jpg"
+        let urlString = settings.buildURLString(path: "/music/\(coverID)/cover_200x200_o.jpg")
 
         guard let url = URL(string: urlString) else {
             completion(nil)
@@ -2335,7 +2335,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPN
 
         // Request 100x100 thumbnail — CarPlay grid images are small.
         // Full-res cover art (1000x1000+) was causing 9s+ load times.
-        let urlString = "http://\(settings.activeServerHost):\(settings.activeServerWebPort)/music/\(artworkId)/cover_200x200_o.jpg"
+        let urlString = settings.buildURLString(path: "/music/\(artworkId)/cover_200x200_o.jpg")
         guard let url = URL(string: urlString) else {
             completion(nil)
             return
@@ -2474,7 +2474,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPN
                 continue
             }
 
-            let urlString = "http://\(settings.activeServerHost):\(settings.activeServerWebPort)/music/\(artworkId)/cover_200x200_o.jpg"
+            let urlString = settings.buildURLString(path: "/music/\(artworkId)/cover_200x200_o.jpg")
 
             guard let url = URL(string: urlString) else {
                 os_log(.error, log: self.logger, "❌ Invalid artwork URL for album ID: %{public}s", album.id)

--- a/LMS_StreamTest/CarPlaySceneDelegate.swift
+++ b/LMS_StreamTest/CarPlaySceneDelegate.swift
@@ -884,7 +884,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPN
             request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         }
 
-        URLSession.shared.dataTask(with: request) { data, _, _ in
+        URLSession.lms.dataTask(with: request) { data, _, _ in
             if let data = data, let image = UIImage(data: data) {
                 completion(image)
             } else {
@@ -2344,7 +2344,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPN
         var request = URLRequest(url: url)
         request.timeoutInterval = 4.0
 
-        URLSession.shared.dataTask(with: request) { data, _, error in
+        URLSession.lms.dataTask(with: request) { data, _, error in
             DispatchQueue.main.async {
                 if let data = data, error == nil, let image = UIImage(data: data) {
                     completion(image)
@@ -2493,7 +2493,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPN
             var request = URLRequest(url: url)
             request.timeoutInterval = 3.0
 
-            URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            URLSession.lms.dataTask(with: request) { [weak self] data, response, error in
                 defer { group.leave() }
 
                 if let error = error {

--- a/LMS_StreamTest/Connections.swift
+++ b/LMS_StreamTest/Connections.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum LMSConnections {
+    static func buildURLString(useHTTPS: Bool, host: String, port: Int, path: String) -> String {
+        let scheme = useHTTPS ? "https" : "http"
+        let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        return "\(scheme)://\(host):\(port)\(normalizedPath)"
+    }
+}

--- a/LMS_StreamTest/Connections.swift
+++ b/LMS_StreamTest/Connections.swift
@@ -7,3 +7,13 @@ enum LMSConnections {
         return "\(scheme)://\(host):\(port)\(normalizedPath)"
     }
 }
+
+extension URLSession {
+    static func lms(host: String, allowSelfSignedCert: Bool) -> URLSession {
+        return URLSession.shared
+    }
+
+    static var lms: URLSession {
+        return URLSession.shared
+    }
+}

--- a/LMS_StreamTest/Connections.swift
+++ b/LMS_StreamTest/Connections.swift
@@ -6,14 +6,68 @@ enum LMSConnections {
         let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
         return "\(scheme)://\(host):\(port)\(normalizedPath)"
     }
+
+    static func handleWebViewChallenge(
+        settings: SettingsManager,
+        challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard settings.activeServerWebUseHTTPS,
+              settings.activeServerAllowSelfSignedCert,
+              let credential = serverTrustCredential(expectedHost: settings.activeServerHost, challenge: challenge) else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        completionHandler(.useCredential, credential)
+    }
+
+    static func serverTrustCredential(expectedHost: String, challenge: URLAuthenticationChallenge) -> URLCredential? {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              challenge.protectionSpace.host == expectedHost,
+              let trust = challenge.protectionSpace.serverTrust else {
+            return nil
+        }
+
+        return URLCredential(trust: trust)
+    }
 }
 
 extension URLSession {
     static func lms(host: String, allowSelfSignedCert: Bool) -> URLSession {
-        return URLSession.shared
+        guard allowSelfSignedCert else {
+            return URLSession.shared
+        }
+
+        let config = URLSessionConfiguration.default
+        let delegate = LMSServerTrustDelegate(expectedHost: host)
+        return URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     }
 
     static var lms: URLSession {
-        return URLSession.shared
+        let settings = SettingsManager.shared
+        return lms(host: settings.activeServerHost, allowSelfSignedCert: settings.activeServerAllowSelfSignedCert)
+    }
+}
+
+private final class LMSServerTrustDelegate: NSObject, URLSessionDelegate {
+    private let expectedHost: String
+
+    init(expectedHost: String) {
+        self.expectedHost = expectedHost
+        super.init()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard let credential = LMSConnections.serverTrustCredential(expectedHost: expectedHost, challenge: challenge) else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        completionHandler(.useCredential, credential)
     }
 }

--- a/LMS_StreamTest/ContentView.swift
+++ b/LMS_StreamTest/ContentView.swift
@@ -1179,6 +1179,18 @@ struct WebView: UIViewRepresentable {
             }
         }
         
+        func webView(
+            _ webView: WKWebView,
+            didReceive challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            LMSConnections.handleWebViewChallenge(
+                settings: SettingsManager.shared,
+                challenge: challenge,
+                completionHandler: completionHandler
+            )
+        }
+
         // MARK: - Handle Direct URL Navigation (Alternative Method)
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             

--- a/LMS_StreamTest/OnboardingViews.swift
+++ b/LMS_StreamTest/OnboardingViews.swift
@@ -207,6 +207,8 @@ struct ServerSetupView: View {
     @State private var slimProtoPort = "3483"
     @State private var serverUsername = ""
     @State private var serverPassword = ""
+    @State private var webUseHTTPS = false
+    @State private var allowSelfSignedCert = false
     @State private var showAuthSection = false
     @State private var validationErrors: [String] = []
     @State private var isDiscovering = false
@@ -289,7 +291,7 @@ struct ServerSetupView: View {
                         )
                     }
 
-                    // Authentication (Optional)
+                    // Authentication + HTTPS (Optional)
                     DisclosureGroup(
                         isExpanded: $showAuthSection,
                         content: {
@@ -326,6 +328,19 @@ struct ServerSetupView: View {
                                     .buttonStyle(SecondaryButtonStyle())
                                     .font(.caption)
                                 }
+
+                                Toggle("Use HTTPS for web interface", isOn: $webUseHTTPS)
+                                    .toggleStyle(SwitchToggleStyle(tint: .blue))
+                                    .foregroundColor(.white)
+
+                                Toggle("Allow self-signed certificate", isOn: $allowSelfSignedCert)
+                                    .toggleStyle(SwitchToggleStyle(tint: .blue))
+                                    .foregroundColor(.white)
+                                    .disabled(!webUseHTTPS)
+
+                                Text("Warning: SlimProto stream/control port remains unencrypted even when HTTPS is enabled.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
                             }
                             .padding(.top, 12)
                         },
@@ -335,7 +350,7 @@ struct ServerSetupView: View {
                                     .foregroundColor(.blue)
                                     .font(.system(size: 16))
 
-                                Text("Advanced: Authentication (Optional)")
+                                Text("Advanced: Authentication & HTTPS")
                                     .font(.subheadline)
                                     .foregroundColor(.white)
 
@@ -753,9 +768,11 @@ struct ServerSetupView: View {
         slimProtoPort = String(settings.activeServerSlimProtoPort)
         serverUsername = settings.serverUsername
         serverPassword = settings.serverPassword
+        webUseHTTPS = settings.serverWebUseHTTPS
+        allowSelfSignedCert = settings.serverAllowSelfSignedCert
 
         // Auto-expand auth section if credentials exist
-        showAuthSection = !serverUsername.isEmpty
+        showAuthSection = !serverUsername.isEmpty || webUseHTTPS || allowSelfSignedCert
     }
     
     private func validateAndProceed() {
@@ -786,6 +803,8 @@ struct ServerSetupView: View {
         settings.serverSlimProtoPort = slimPortInt
         settings.serverUsername = serverUsername.trimmingCharacters(in: .whitespacesAndNewlines)
         settings.serverPassword = serverPassword
+        settings.serverWebUseHTTPS = webUseHTTPS
+        settings.serverAllowSelfSignedCert = webUseHTTPS ? allowSelfSignedCert : false
 
         // saveSettings() will automatically save credentials to Keychain
         settings.saveSettings()
@@ -924,6 +943,8 @@ struct ConnectionTestView: View {
                 host: settings.serverHost,
                 webPort: settings.serverWebPort,
                 slimProtoPort: settings.serverSlimProtoPort,
+                webUseHTTPS: settings.serverWebUseHTTPS,
+                allowSelfSignedCert: settings.serverAllowSelfSignedCert,
                 authHeader: auth
             )
 

--- a/LMS_StreamTest/SettingsManager.swift
+++ b/LMS_StreamTest/SettingsManager.swift
@@ -12,6 +12,8 @@ class SettingsManager: ObservableObject {
     // MARK: - Published Properties
     @Published var serverHost: String = ""
     @Published var serverWebPort: Int = 9000
+    @Published var serverWebUseHTTPS: Bool = false
+    @Published var serverAllowSelfSignedCert: Bool = false
     @Published var serverSlimProtoPort: Int = 3483
     @Published var playerName: String = ""
     @Published var connectionTimeout: TimeInterval = 8.0
@@ -24,6 +26,8 @@ class SettingsManager: ObservableObject {
     @Published var shouldReloadWebView: Bool = false
     @Published var backupServerHost: String = ""
     @Published var backupServerWebPort: Int = 9000
+    @Published var backupServerWebUseHTTPS: Bool = false
+    @Published var backupServerAllowSelfSignedCert: Bool = false
     @Published var backupServerSlimProtoPort: Int = 3483
     @Published var isBackupServerEnabled: Bool = false
     @Published var automaticFailoverEnabled: Bool = true
@@ -145,6 +149,8 @@ class SettingsManager: ObservableObject {
     private enum Keys {
         static let serverHost = "ServerHost"
         static let serverWebPort = "ServerWebPort"
+        static let serverWebUseHTTPS = "ServerWebUseHTTPS"
+        static let serverAllowSelfSignedCert = "ServerAllowSelfSignedCert"
         static let serverSlimProtoPort = "ServerSlimProtoPort"
         static let playerName = "PlayerName"
         static let playerMACAddress = "PlayerMACAddress"
@@ -157,6 +163,8 @@ class SettingsManager: ObservableObject {
         static let showFallbackSettingsButton = "ShowFallbackSettingsButton"
         static let backupServerHost = "BackupServerHost"
         static let backupServerWebPort = "BackupServerWebPort"
+        static let backupServerWebUseHTTPS = "BackupServerWebUseHTTPS"
+        static let backupServerAllowSelfSignedCert = "BackupServerAllowSelfSignedCert"
         static let backupServerSlimProtoPort = "BackupServerSlimProtoPort"
         static let isBackupServerEnabled = "IsBackupServerEnabled"
         static let automaticFailoverEnabled = "AutomaticFailoverEnabled"
@@ -304,6 +312,8 @@ class SettingsManager: ObservableObject {
         
         serverHost = UserDefaults.standard.string(forKey: Keys.serverHost) ?? ""
         serverWebPort = UserDefaults.standard.object(forKey: Keys.serverWebPort) as? Int ?? 9000
+        serverWebUseHTTPS = UserDefaults.standard.object(forKey: Keys.serverWebUseHTTPS) as? Bool ?? false
+        serverAllowSelfSignedCert = UserDefaults.standard.object(forKey: Keys.serverAllowSelfSignedCert) as? Bool ?? false
         serverSlimProtoPort = UserDefaults.standard.object(forKey: Keys.serverSlimProtoPort) as? Int ?? 3483
         playerName = UserDefaults.standard.string(forKey: Keys.playerName) ?? ""
         playerMACAddress = UserDefaults.standard.string(forKey: Keys.playerMACAddress) ?? ""
@@ -315,6 +325,8 @@ class SettingsManager: ObservableObject {
         showFallbackSettingsButton = UserDefaults.standard.object(forKey: Keys.showFallbackSettingsButton) as? Bool ?? true
         backupServerHost = UserDefaults.standard.string(forKey: Keys.backupServerHost) ?? ""
         backupServerWebPort = UserDefaults.standard.object(forKey: Keys.backupServerWebPort) as? Int ?? 9000
+        backupServerWebUseHTTPS = UserDefaults.standard.object(forKey: Keys.backupServerWebUseHTTPS) as? Bool ?? false
+        backupServerAllowSelfSignedCert = UserDefaults.standard.object(forKey: Keys.backupServerAllowSelfSignedCert) as? Bool ?? false
         backupServerSlimProtoPort = UserDefaults.standard.object(forKey: Keys.backupServerSlimProtoPort) as? Int ?? 3483
         isBackupServerEnabled = UserDefaults.standard.bool(forKey: Keys.isBackupServerEnabled)
         automaticFailoverEnabled = UserDefaults.standard.object(forKey: Keys.automaticFailoverEnabled) as? Bool ?? true
@@ -373,6 +385,8 @@ class SettingsManager: ObservableObject {
         
         UserDefaults.standard.set(serverHost, forKey: Keys.serverHost)
         UserDefaults.standard.set(serverWebPort, forKey: Keys.serverWebPort)
+        UserDefaults.standard.set(serverWebUseHTTPS, forKey: Keys.serverWebUseHTTPS)
+        UserDefaults.standard.set(serverAllowSelfSignedCert, forKey: Keys.serverAllowSelfSignedCert)
         UserDefaults.standard.set(serverSlimProtoPort, forKey: Keys.serverSlimProtoPort)
         UserDefaults.standard.set(playerName, forKey: Keys.playerName)
         UserDefaults.standard.set(playerMACAddress, forKey: Keys.playerMACAddress)
@@ -385,6 +399,8 @@ class SettingsManager: ObservableObject {
         UserDefaults.standard.set(showFallbackSettingsButton, forKey: Keys.showFallbackSettingsButton)
         UserDefaults.standard.set(backupServerHost, forKey: Keys.backupServerHost)
         UserDefaults.standard.set(backupServerWebPort, forKey: Keys.backupServerWebPort)
+        UserDefaults.standard.set(backupServerWebUseHTTPS, forKey: Keys.backupServerWebUseHTTPS)
+        UserDefaults.standard.set(backupServerAllowSelfSignedCert, forKey: Keys.backupServerAllowSelfSignedCert)
         UserDefaults.standard.set(backupServerSlimProtoPort, forKey: Keys.backupServerSlimProtoPort)
         UserDefaults.standard.set(isBackupServerEnabled, forKey: Keys.isBackupServerEnabled)
         UserDefaults.standard.set(automaticFailoverEnabled, forKey: Keys.automaticFailoverEnabled)
@@ -518,6 +534,8 @@ class SettingsManager: ObservableObject {
         host: String,
         webPort: Int,
         slimProtoPort: Int,
+        webUseHTTPS: Bool,
+        allowSelfSignedCert: Bool,
         authHeader: String?
     ) async -> ConnectionTestResult {
         os_log(.info, log: logger, "Testing connection to %{public}s", host)
@@ -532,8 +550,8 @@ class SettingsManager: ObservableObject {
         let webTestResult = await testHTTPConnection(
             host: cleanHost,
             port: webPort,
-            useHTTPS: false,
-            allowSelfSignedCert: false,
+            useHTTPS: webUseHTTPS,
+            allowSelfSignedCert: allowSelfSignedCert,
             authHeader: authHeader
         )
         switch webTestResult {
@@ -686,12 +704,16 @@ class SettingsManager: ObservableObject {
         playerName = Self.defaultPlayerName
         isConfigured = false
         serverWebPort = 9000
+        serverWebUseHTTPS = false
+        serverAllowSelfSignedCert = false
         serverSlimProtoPort = 3483
         connectionTimeout = 10.0
 
         // CRITICAL FIX: Reset backup server settings
         backupServerHost = ""
         backupServerWebPort = 9000
+        backupServerWebUseHTTPS = false
+        backupServerAllowSelfSignedCert = false
         backupServerSlimProtoPort = 3483
         isBackupServerEnabled = false
         automaticFailoverEnabled = true
@@ -746,6 +768,14 @@ class SettingsManager: ObservableObject {
         return currentActiveServer == .primary ? serverHost : backupServerHost
     }
 
+    var activeServerWebUseHTTPS: Bool {
+        return currentActiveServer == .primary ? serverWebUseHTTPS : backupServerWebUseHTTPS
+    }
+
+    var activeServerAllowSelfSignedCert: Bool {
+        return currentActiveServer == .primary ? serverAllowSelfSignedCert : backupServerAllowSelfSignedCert
+    }
+
     var activeServerWebPort: Int {
         return currentActiveServer == .primary ? serverWebPort : backupServerWebPort
     }
@@ -783,7 +813,7 @@ class SettingsManager: ObservableObject {
     }
 
     func buildURLString(path: String) -> String {
-        LMSConnections.buildURLString(useHTTPS: false, host: activeServerHost, port: activeServerWebPort, path: path)
+        LMSConnections.buildURLString(useHTTPS: activeServerWebUseHTTPS, host: activeServerHost, port: activeServerWebPort, path: path)
     }
 
     /// Reconcile a freshly-fetched plugin-shelf registry against persisted

--- a/LMS_StreamTest/SettingsManager.swift
+++ b/LMS_StreamTest/SettingsManager.swift
@@ -533,6 +533,7 @@ class SettingsManager: ObservableObject {
             host: cleanHost,
             port: webPort,
             useHTTPS: false,
+            allowSelfSignedCert: false,
             authHeader: authHeader
         )
         switch webTestResult {
@@ -568,6 +569,7 @@ class SettingsManager: ObservableObject {
         host: String,
         port: Int,
         useHTTPS: Bool,
+        allowSelfSignedCert: Bool,
         authHeader: String?
     ) async -> PortTestResult {
         let urlString = LMSConnections.buildURLString(
@@ -591,7 +593,7 @@ class SettingsManager: ObservableObject {
         request.timeoutInterval = connectionTimeout
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await URLSession.lms(host: host, allowSelfSignedCert: allowSelfSignedCert).data(for: request)
 
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode < 400 {

--- a/LMS_StreamTest/SettingsManager.swift
+++ b/LMS_StreamTest/SettingsManager.swift
@@ -529,7 +529,12 @@ class SettingsManager: ObservableObject {
 
         // Note: Local network permission is triggered by server discovery UDP broadcasts
 
-        let webTestResult = await testHTTPConnection(host: cleanHost, port: webPort, authHeader: authHeader)
+        let webTestResult = await testHTTPConnection(
+            host: cleanHost,
+            port: webPort,
+            useHTTPS: false,
+            authHeader: authHeader
+        )
         switch webTestResult {
         case .offline(let msg):
             return .networkError(msg)
@@ -559,8 +564,18 @@ class SettingsManager: ObservableObject {
         case offline(String)
     }
 
-    private func testHTTPConnection(host: String, port: Int, authHeader: String?) async -> PortTestResult {
-        guard let url = URL(string: "http://\(host):\(port)/") else {
+    private func testHTTPConnection(
+        host: String,
+        port: Int,
+        useHTTPS: Bool,
+        authHeader: String?
+    ) async -> PortTestResult {
+        let urlString = LMSConnections.buildURLString(
+            useHTTPS: useHTTPS,
+            host: host,
+            port: port,
+            path: "/")
+        guard let url = URL(string: urlString) else {
             return .failure("Invalid URL format")
         }
 
@@ -691,7 +706,7 @@ class SettingsManager: ObservableObject {
     
     // MARK: - Computed Properties
     var webURL: String {
-        let baseURL = "http://\(activeServerHost):\(activeServerWebPort)/material/"
+        let baseURL = buildURLString(path: "/material/")
         // Inject credentials for authenticated servers (Material's AJAX calls need them)
         return injectCredentialsIntoURL(baseURL)
     }
@@ -762,7 +777,11 @@ class SettingsManager: ObservableObject {
         }
         guard !activeServerHost.isEmpty else { return nil }
         let p = path.hasPrefix("/") ? path : "/\(path)"
-        return URL(string: "http://\(activeServerHost):\(activeServerWebPort)\(p)")
+        return URL(string: buildURLString(path: p))
+    }
+
+    func buildURLString(path: String) -> String {
+        LMSConnections.buildURLString(useHTTPS: false, host: activeServerHost, port: activeServerWebPort, path: path)
     }
 
     /// Reconcile a freshly-fetched plugin-shelf registry against persisted

--- a/LMS_StreamTest/SettingsView.swift
+++ b/LMS_StreamTest/SettingsView.swift
@@ -546,6 +546,8 @@ struct SettingsView: View {
                         host: settings.serverHost,
                         webPort: settings.serverWebPort,
                         slimProtoPort: settings.serverSlimProtoPort,
+                        webUseHTTPS: settings.serverWebUseHTTPS,
+                        allowSelfSignedCert: settings.serverAllowSelfSignedCert,
                         authHeader: auth
                     )
                     return (settings.serverHost, settings.serverWebPort, settings.serverSlimProtoPort, r)
@@ -556,6 +558,8 @@ struct SettingsView: View {
                         host: settings.backupServerHost,
                         webPort: settings.backupServerWebPort,
                         slimProtoPort: settings.backupServerSlimProtoPort,
+                        webUseHTTPS: settings.backupServerWebUseHTTPS,
+                        allowSelfSignedCert: settings.backupServerAllowSelfSignedCert,
                         authHeader: auth
                     )
                     return (settings.backupServerHost, settings.backupServerWebPort, settings.backupServerSlimProtoPort, r)
@@ -649,6 +653,8 @@ struct ServerConfigView: View {
     @State private var serverHost: String = ""
     @State private var serverUsername: String = ""
     @State private var serverPassword: String = ""
+    @State private var webUseHTTPS: Bool = false
+    @State private var allowSelfSignedCert: Bool = false
     @State private var validationErrors: [String] = []
     @State private var showingConnectionTest = false
     @State private var hasChanges = false
@@ -694,6 +700,19 @@ struct ServerConfigView: View {
                 }
             }
 
+            Section(header: Text("Web Security")) {
+                Toggle("Use HTTPS for web interface", isOn: $webUseHTTPS)
+                    .onChange(of: webUseHTTPS) { _ in hasChanges = true }
+
+                Toggle("Allow self-signed certificate", isOn: $allowSelfSignedCert)
+                    .disabled(!webUseHTTPS)
+                    .onChange(of: allowSelfSignedCert) { _ in hasChanges = true }
+
+                Text("Warning: SlimProto stream/control port remains unencrypted even when HTTPS is enabled.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             if !validationErrors.isEmpty {
                 Section(header: Text("Validation Errors")) {
                     ForEach(validationErrors, id: \.self) { error in
@@ -735,6 +754,8 @@ struct ServerConfigView: View {
                         host: typed,
                         webPort: settings.serverWebPort,
                         slimProtoPort: settings.serverSlimProtoPort,
+                        webUseHTTPS: settings.serverWebUseHTTPS,
+                        allowSelfSignedCert: settings.serverAllowSelfSignedCert,
                         authHeader: auth
                     )
                     return (typed, settings.serverWebPort, settings.serverSlimProtoPort, r)
@@ -769,6 +790,8 @@ struct ServerConfigView: View {
         settings.serverHost = trimmedHost
         settings.serverUsername = serverUsername.trimmingCharacters(in: .whitespacesAndNewlines)
         settings.serverPassword = serverPassword
+        settings.serverWebUseHTTPS = webUseHTTPS
+        settings.serverAllowSelfSignedCert = webUseHTTPS ? allowSelfSignedCert : false
 
         settings.saveSettings()
         hasChanges = false
@@ -1325,6 +1348,8 @@ struct BackupServerConfigView: View {
     @State private var backupSlimPort: String = "3483"
     @State private var backupUsername: String = ""
     @State private var backupPassword: String = ""
+    @State private var backupWebUseHTTPS: Bool = false
+    @State private var backupAllowSelfSignedCert: Bool = false
     @State private var hasChanges = false
     @State private var validationErrors: [String] = []
     @State private var showingConnectionTest = false
@@ -1399,6 +1424,19 @@ struct BackupServerConfigView: View {
                 }
             }
 
+            Section(header: Text("Web Security")) {
+                Toggle("Use HTTPS for web interface", isOn: $backupWebUseHTTPS)
+                    .onChange(of: backupWebUseHTTPS) { _ in hasChanges = true }
+
+                Toggle("Allow self-signed certificate", isOn: $backupAllowSelfSignedCert)
+                    .disabled(!backupWebUseHTTPS)
+                    .onChange(of: backupAllowSelfSignedCert) { _ in hasChanges = true }
+
+                Text("Warning: SlimProto stream/control port remains unencrypted even when HTTPS is enabled.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             if !validationErrors.isEmpty {
                 Section(header: Text("Validation Errors")) {
                     ForEach(validationErrors, id: \.self) { error in
@@ -1442,6 +1480,8 @@ struct BackupServerConfigView: View {
                         host: host,
                         webPort: web,
                         slimProtoPort: slim,
+                        webUseHTTPS: backupWebUseHTTPS,
+                        allowSelfSignedCert: backupAllowSelfSignedCert,
                         authHeader: auth
                     )
                     return (host, web, slim, r)
@@ -1460,6 +1500,8 @@ struct BackupServerConfigView: View {
         backupSlimPort = String(settings.backupServerSlimProtoPort)
         backupUsername = settings.backupServerUsername
         backupPassword = settings.backupServerPassword
+        backupWebUseHTTPS = settings.backupServerWebUseHTTPS
+        backupAllowSelfSignedCert = settings.backupServerAllowSelfSignedCert
     }
     
     private func saveSettings() {
@@ -1487,6 +1529,8 @@ struct BackupServerConfigView: View {
         settings.backupServerSlimProtoPort = slimPortInt
         settings.backupServerUsername = backupUsername.trimmingCharacters(in: .whitespacesAndNewlines)
         settings.backupServerPassword = backupPassword
+        settings.backupServerWebUseHTTPS = backupWebUseHTTPS
+        settings.backupServerAllowSelfSignedCert = backupAllowSelfSignedCert
         settings.saveSettings()
         hasChanges = false
         

--- a/LMS_StreamTest/SlimProtoCommandHandler.swift
+++ b/LMS_StreamTest/SlimProtoCommandHandler.swift
@@ -544,9 +544,7 @@ class SlimProtoCommandHandler: ObservableObject {
         guard parts.count >= 2 else { return nil }
         
         let path = parts[1]
-        let webPort = settings.activeServerWebPort
-        let host = settings.activeServerHost
-        let fullURL = "http://\(host):\(webPort)\(path)"
+        let fullURL = settings.buildURLString(path: path)
         
         os_log(.info, log: logger, "🔍 Extracted stream URL: %{public}s", fullURL)
         return fullURL

--- a/LMS_StreamTest/SlimProtoCoordinator.swift
+++ b/LMS_StreamTest/SlimProtoCoordinator.swift
@@ -1783,7 +1783,7 @@ extension SlimProtoCoordinator {
         request.httpBody = jsonData
         request.timeoutInterval = 5.0
         
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+        URLSession.lms.dataTask(with: request) { [weak self] data, response, error in
             DispatchQueue.main.async {
                 self?.parseServerTimeResponse(data: data, error: error)
             }
@@ -2123,7 +2123,7 @@ extension SlimProtoCoordinator {
             request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         }
 
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        let task = URLSession.lms.dataTask(with: request) { data, response, error in
             DispatchQueue.main.async {
                 if let error = error {
                     os_log(.error, log: self.logger, "JSON-RPC %{public}s failed: %{public}s", command, error.localizedDescription)
@@ -2190,7 +2190,7 @@ extension SlimProtoCoordinator {
         request.httpBody = jsonData
         request.timeoutInterval = 5.0
         
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        let task = URLSession.lms.dataTask(with: request) { data, response, error in
             if let error = error {
                 os_log(.error, log: self.logger, "❌ JSON-RPC request failed: %{public}s", error.localizedDescription)
                 completion([:])
@@ -2635,7 +2635,7 @@ extension SlimProtoCoordinator {
             request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         }
 
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        let task = URLSession.lms.dataTask(with: request) { data, response, error in
             if let error = error {
                 os_log(.error, log: self.logger, "Enhanced metadata request failed: %{public}s", error.localizedDescription)
                 return

--- a/LMS_StreamTest/SlimProtoCoordinator.swift
+++ b/LMS_StreamTest/SlimProtoCoordinator.swift
@@ -1765,9 +1765,7 @@ extension SlimProtoCoordinator {
             return
         }
         
-        let webPort = settings.activeServerWebPort
-        let host = settings.activeServerHost
-        guard let url = URL(string: "http://\(host):\(webPort)/jsonrpc.js") else {
+        guard let url = URL(string: settings.buildURLString(path: "/jsonrpc.js")) else {
             return
         }
         
@@ -2108,9 +2106,7 @@ extension SlimProtoCoordinator {
             return
         }
         
-        let webPort = settings.activeServerWebPort
-        let host = settings.activeServerHost
-        guard let url = URL(string: "http://\(host):\(webPort)/jsonrpc.js") else {
+        guard let url = URL(string: settings.buildURLString(path: "/jsonrpc.js")) else {
             os_log(.error, log: logger, "Invalid server URL for JSON-RPC")
             return
         }
@@ -2171,7 +2167,7 @@ extension SlimProtoCoordinator {
         // CRITICAL FIX: Use direct LMS endpoint instead of Material's /material/jsonrpc.js
         // Material endpoint can apply commands to wrong player based on Material UI session state
         // Direct endpoint ensures player MAC in params[0] is always respected
-        let urlString = "http://\(settings.activeServerHost):\(settings.activeServerWebPort)/jsonrpc.js"
+        let urlString = settings.buildURLString(path: "/jsonrpc.js")
         os_log(.debug, log: logger, "🌐 JSON-RPC URL: %{public}s", urlString)
         
         guard let url = URL(string: urlString) else {
@@ -2627,9 +2623,7 @@ extension SlimProtoCoordinator {
             return
         }
         
-        let webPort = settings.activeServerWebPort
-        let host = settings.activeServerHost
-        var request = URLRequest(url: URL(string: "http://\(host):\(webPort)/jsonrpc.js")!)
+        var request = URLRequest(url: URL(string: settings.buildURLString(path: "/jsonrpc.js"))!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(settings.customUserAgent, forHTTPHeaderField: "User-Agent")
@@ -2698,9 +2692,9 @@ extension SlimProtoCoordinator {
                 // SIMPLIFIED: Basic artwork detection
                 var artworkURL: String? = nil
                 if let artwork = firstTrack["artwork_url"] as? String, !artwork.isEmpty {
-                    artworkURL = artwork.hasPrefix("http") ? artwork : "http://\(settings.activeServerHost):\(settings.activeServerWebPort)\(artwork)"
+                    artworkURL = artwork.hasPrefix("http") ? artwork : settings.buildURLString(path: artwork)
                 } else if let coverid = firstTrack["coverid"] as? String, !coverid.isEmpty, coverid != "0" {
-                    artworkURL = "http://\(settings.activeServerHost):\(settings.activeServerWebPort)/music/\(coverid)/cover.jpg"
+                    artworkURL = settings.buildURLString(path: "/music/\(coverid)/cover.jpg")
                 }
 
                 // Inject credentials for password-protected LMS servers


### PR DESCRIPTION
This PR solves #98, and adds support for https connections, including support for self-signed certificates (which is likely to be common on typical home setups where you expose Lyrion using https).

* Note: Using https will protect the confidentiality of data, but it will not restrict access to the server. I strongly recommend combining this with http authorization. Having http authorization without https on the open internet is dangerous, since the password is sent in clear, but when combined with ssl it provides a decent amount of protection, for most reasonable situations what you need for a home Lyrion setup.
* Note 2: The web interface is protected by https, but not the SlimProto channel. This includes slim commands as well as streaming data, so it is not ideal. But it seems pretty unlikely that anybody could use this for any nefarious reasons, more than maybe hacking your Metallica stream and replacing it with blue grass or something like that.. :-)

This is my first time hacking iOS apps, but I think I got it figured out in the end. :) I have verified the functionality on the Simulator.